### PR TITLE
credentialStatus: support array form + emit structured StatusCheckEntry

### DIFF
--- a/ssi-ldp/src/lib.rs
+++ b/ssi-ldp/src/lib.rs
@@ -77,6 +77,57 @@ pub struct VerificationResult {
     pub warnings: Vec<String>,
     /// Errors
     pub errors: Vec<String>,
+    /// Per-entry results for the credentialStatus check.
+    ///
+    /// Populated by the status-list verifiers in `ssi-vc::revocation`
+    /// when a credential carries one or more `credentialStatus`
+    /// entries. The shape preserves the entry type, claimed purpose
+    /// (e.g. `"revocation"` / `"suspension"`), and whether the bit
+    /// at the credential's index in the status list was set, so
+    /// downstream consumers can render structured UI ("this
+    /// credential was revoked" vs "suspended" vs "active") without
+    /// string-matching on the human-readable error text.
+    ///
+    /// Empty for credentials without a `credentialStatus`, and for
+    /// non-VC verification flows. Serialized only when non-empty
+    /// to avoid breaking existing wire consumers that pre-date this
+    /// field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status: Vec<StatusCheckEntry>,
+}
+
+/// Structured result for a single `credentialStatus` entry.
+///
+/// One of these is appended to `VerificationResult::status` for each
+/// status entry the verifier processes. When the bit is set
+/// (`is_set = true`) and the entry's purpose is `"revocation"` or
+/// `"suspension"`, the verifier ALSO records a human-readable error
+/// in `errors` for backwards compatibility with existing consumers.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusCheckEntry {
+    /// The `credentialStatus.type` value as it appeared on the
+    /// credential — e.g. `"BitstringStatusListEntry"`,
+    /// `"StatusList2021Entry"`, `"RevocationList2020Status"`.
+    pub entry_type: String,
+    /// The `statusPurpose` claimed by the entry. Standard values are
+    /// `"revocation"` and `"suspension"`; the spec allows arbitrary
+    /// strings, so this is left as a free-form `String` rather than
+    /// an enum.
+    pub status_purpose: String,
+    /// `true` if the bit at the credential's index in the status
+    /// list bitstring is set. Combined with `status_purpose`, this
+    /// is what callers use to determine "revoked", "suspended", etc.
+    pub is_set: bool,
+    /// URL of the Status List Credential, if known. Always populated
+    /// for `BitstringStatusListEntry` and `StatusList2021Entry`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_list_credential: Option<String>,
+    /// The credential's index within the status list bitstring, as
+    /// the original (pre-parse) string so callers can round-trip it
+    /// without numeric loss.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_list_index: Option<String>,
 }
 
 impl VerificationResult {
@@ -89,6 +140,7 @@ impl VerificationResult {
             checks: vec![],
             warnings: vec![],
             errors: vec![err.to_string()],
+            status: vec![],
         }
     }
 
@@ -96,10 +148,18 @@ impl VerificationResult {
         self.checks.append(&mut other.checks);
         self.warnings.append(&mut other.warnings);
         self.errors.append(&mut other.errors);
+        self.status.append(&mut other.status);
     }
 
     pub fn with_error(mut self, error: String) -> Self {
         self.errors.push(error);
+        self
+    }
+
+    /// Attach a structured `StatusCheckEntry` to this result. Used
+    /// by the `credentialStatus` verifiers in `ssi-vc::revocation`.
+    pub fn with_status(mut self, entry: StatusCheckEntry) -> Self {
+        self.status.push(entry);
         self
     }
 }
@@ -111,11 +171,13 @@ impl From<Result<VerificationWarnings, Error>> for VerificationResult {
                 checks: vec![],
                 warnings,
                 errors: vec![],
+                status: vec![],
             },
             Err(error) => Self {
                 checks: vec![],
                 warnings: vec![],
                 errors: vec![error.to_string()],
+                status: vec![],
             },
         }
     }

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -71,8 +71,15 @@ pub struct Credential {
     pub proof: Option<OneOrMany<Proof>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration_date: Option<VCDateTime>,
+    /// `credentialStatus` per the W3C VC Data Model. The 1.x model
+    /// allowed a single object; the 2.0 model explicitly allows a
+    /// set (`OneOrMany<Status>`). We accept either to stay
+    /// spec-conformant for both versions — a single object
+    /// deserializes to `OneOrMany::One`, an array to
+    /// `OneOrMany::Many`. `Credential::check_status` walks every
+    /// entry independently and aggregates results.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub credential_status: Option<Status>,
+    pub credential_status: Option<OneOrMany<Status>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terms_of_use: Option<Vec<TermsOfUse>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1153,7 +1160,17 @@ impl Credential {
         }
     }
 
-    /// Check the credentials [status](https://www.w3.org/TR/vc-data-model/#status)
+    /// Check the credential's [status](https://www.w3.org/TR/vc-data-model/#status).
+    ///
+    /// VC 2.0 explicitly allows `credentialStatus` to be a set of
+    /// entries (e.g., a separate revocation entry and suspension
+    /// entry). VC 1.1 producers in the wild use a single object.
+    /// Both shapes round-trip through `OneOrMany<Status>`; this
+    /// method walks every entry, aggregating each per-entry
+    /// `VerificationResult` (errors, warnings, structured `status`
+    /// rows) into one combined result. The `Check::Status` marker is
+    /// only appended once, after every entry has been processed
+    /// without errors.
     pub async fn check_status(
         &self,
         resolver: &dyn DIDResolver,
@@ -1163,28 +1180,47 @@ impl Credential {
             Some(ref status) => status,
             None => return VerificationResult::error("Missing credentialStatus"),
         };
-        let status_value = match serde_json::to_value(status.clone()) {
-            Ok(status) => status,
-            Err(e) => {
-                return VerificationResult::error(&format!(
-                    "Unable to convert credentialStatus: {}",
-                    e
-                ))
+
+        let mut result = VerificationResult::new();
+
+        for entry in status.into_iter() {
+            let status_value = match serde_json::to_value(entry.clone()) {
+                Ok(status) => status,
+                Err(e) => {
+                    result.errors.push(format!(
+                        "Unable to convert credentialStatus: {}",
+                        e
+                    ));
+                    return result;
+                }
+            };
+
+            let checkable_status: CheckableStatus =
+                match serde_json::from_value(status_value) {
+                    Ok(checkable_status) => checkable_status,
+                    Err(e) => {
+                        result.errors.push(format!(
+                            "Unable to parse credentialStatus: {}",
+                            e
+                        ));
+                        return result;
+                    }
+                };
+
+            let mut entry_result =
+                checkable_status.check(self, resolver, context_loader).await;
+            result.append(&mut entry_result);
+
+            // Stop on the first failing entry — the credential is
+            // already not honourable, no need to consult the rest of
+            // the list (and the rest may have unrelated network
+            // failures we don't want to mask the real revocation
+            // with).
+            if !result.errors.is_empty() {
+                return result;
             }
-        };
-        let checkable_status: CheckableStatus = match serde_json::from_value(status_value) {
-            Ok(checkable_status) => checkable_status,
-            Err(e) => {
-                return VerificationResult::error(&format!(
-                    "Unable to parse credentialStatus: {}",
-                    e
-                ))
-            }
-        };
-        let mut result = checkable_status.check(self, resolver, context_loader).await;
-        if !result.errors.is_empty() {
-            return result;
         }
+
         result.checks.push(Check::Status);
         result
     }
@@ -3024,6 +3060,15 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             .await;
         println!("{:#?}", verification_result);
         assert_eq!(verification_result.errors.len(), 0);
+        // RevocationList2020Status synthesizes statusPurpose
+        // = "revocation" since the type itself doesn't carry one.
+        assert_eq!(verification_result.status.len(), 1);
+        assert_eq!(
+            verification_result.status[0].entry_type,
+            "RevocationList2020Status"
+        );
+        assert_eq!(verification_result.status[0].status_purpose, "revocation");
+        assert!(!verification_result.status[0].is_set);
 
         // Verify revoked VC
         let verification_result = revoked_vc
@@ -3031,6 +3076,8 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             .await;
         println!("{:#?}", verification_result);
         assert_ne!(verification_result.errors.len(), 0);
+        assert_eq!(verification_result.status.len(), 1);
+        assert!(verification_result.status[0].is_set);
     }
 
     #[async_std::test]
@@ -3067,6 +3114,9 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             .await;
         println!("{:#?}", vres);
         assert_eq!(vres.errors.len(), 0);
+        assert_eq!(vres.status.len(), 1);
+        assert_eq!(vres.status[0].entry_type, "StatusList2021Entry");
+        assert!(!vres.status[0].is_set);
 
         let revoked_credential: Credential = serde_json::from_value(json!({
           "@context": [
@@ -3096,6 +3146,9 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             .await;
         println!("{:#?}", vres);
         assert_ne!(vres.errors.len(), 0);
+        assert_eq!(vres.status.len(), 1);
+        assert_eq!(vres.status[0].entry_type, "StatusList2021Entry");
+        assert!(vres.status[0].is_set);
     }
 
     #[async_std::test]
@@ -3129,6 +3182,16 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         println!("{:#?}", vres);
         assert_eq!(vres.errors.len(), 0);
 
+        // Structured outcome: an active credential should still
+        // emit a StatusCheckEntry with is_set=false so consumers
+        // can affirmatively render "active" rather than guessing
+        // from the absence of an error.
+        assert_eq!(vres.status.len(), 1);
+        assert_eq!(vres.status[0].entry_type, "BitstringStatusListEntry");
+        assert_eq!(vres.status[0].status_purpose, "revocation");
+        assert!(!vres.status[0].is_set);
+        assert_eq!(vres.status[0].status_list_index.as_deref(), Some("94567"));
+
         let revoked_credential: Credential = serde_json::from_value(json!({
           "@context": [
             "https://www.w3.org/ns/credentials/v2"
@@ -3156,6 +3219,142 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             .await;
         println!("{:#?}", vres);
         assert_ne!(vres.errors.len(), 0);
+
+        // Structured outcome on the revoked branch: human-readable
+        // error AND structured entry should both be present, so
+        // legacy consumers (errors only) and new consumers
+        // (status[]) both work.
+        assert_eq!(vres.status.len(), 1);
+        assert_eq!(vres.status[0].entry_type, "BitstringStatusListEntry");
+        assert_eq!(vres.status[0].status_purpose, "revocation");
+        assert!(vres.status[0].is_set);
+    }
+
+    #[async_std::test]
+    async fn credential_status_array_form() {
+        // VC 2.0 §4.9 explicitly allows credentialStatus to be a
+        // set. This test exercises a credential carrying two
+        // BitstringStatusListEntry rows in array form — one
+        // revocation-purpose entry pointing at an unset index
+        // (active), and one suspension-purpose entry also at an
+        // unset index. Both entries should round-trip through
+        // OneOrMany::Many, both should be checked, and both
+        // should appear in VerificationResult::status.
+        use serde_json::json;
+        let credential: Credential = serde_json::from_value(json!({
+          "@context": ["https://www.w3.org/ns/credentials/v2"],
+          "id": "https://example.com/credentials/array-status",
+          "type": ["VerifiableCredential"],
+          "issuer": "did:example:12345",
+          "validFrom": "2021-04-05T14:27:42Z",
+          "credentialStatus": [
+            {
+              "type": "BitstringStatusListEntry",
+              "statusPurpose": "revocation",
+              "statusListIndex": "94567",
+              "statusListCredential": EXAMPLE_BITSTRING_STATUS_LIST_URL
+            },
+            {
+              "type": "BitstringStatusListEntry",
+              "statusPurpose": "suspension",
+              "statusListIndex": "94568",
+              "statusListCredential": EXAMPLE_BITSTRING_STATUS_LIST_URL
+            }
+          ],
+          "credentialSubject": {
+            "id": "did:example:6789",
+            "type": "Person"
+          }
+        }))
+        .unwrap();
+
+        // Confirm OneOrMany::Many round-trip. If the field were
+        // still typed as Option<Status>, the from_value above
+        // would have failed.
+        match credential.credential_status {
+            Some(OneOrMany::Many(ref entries)) => assert_eq!(entries.len(), 2),
+            other => panic!("expected Many(2), got {:?}", other),
+        }
+
+        let mut context_loader = ssi_json_ld::ContextLoader::default();
+        let vres = credential
+            .check_status(&DIDExample, &mut context_loader)
+            .await;
+        println!("{:#?}", vres);
+        assert_eq!(vres.errors.len(), 0);
+
+        // Both entries should have been processed and recorded.
+        assert_eq!(vres.status.len(), 2);
+        assert_eq!(vres.status[0].status_purpose, "revocation");
+        assert!(!vres.status[0].is_set);
+        assert_eq!(vres.status[1].status_purpose, "suspension");
+        assert!(!vres.status[1].is_set);
+
+        // The Status check marker is appended exactly once even
+        // though we processed two entries.
+        assert_eq!(
+            vres.checks
+                .iter()
+                .filter(|c| matches!(c, Check::Status))
+                .count(),
+            1
+        );
+    }
+
+    #[async_std::test]
+    async fn credential_status_array_form_short_circuits_on_revoked() {
+        // When the first entry in an array-form credentialStatus
+        // is revoked, the second entry should NOT be processed —
+        // we don't want to hit the network for additional list
+        // fetches when the credential is already known to be
+        // dishonourable, and we don't want a second entry's
+        // unrelated network failure to mask a real revocation.
+        use serde_json::json;
+        let credential: Credential = serde_json::from_value(json!({
+          "@context": ["https://www.w3.org/ns/credentials/v2"],
+          "id": "https://example.com/credentials/array-status-revoked",
+          "type": ["VerifiableCredential"],
+          "issuer": "did:example:12345",
+          "validFrom": "2021-04-05T14:27:42Z",
+          "credentialStatus": [
+            {
+              "type": "BitstringStatusListEntry",
+              "statusPurpose": "revocation",
+              "statusListIndex": "1",
+              "statusListCredential": EXAMPLE_BITSTRING_STATUS_LIST_URL
+            },
+            {
+              // Pointing at an intentionally-bogus URL — if this
+              // entry were checked it would error on the network
+              // load. The short-circuit guarantees we never
+              // reach it.
+              "type": "BitstringStatusListEntry",
+              "statusPurpose": "suspension",
+              "statusListIndex": "0",
+              "statusListCredential": "https://nope.invalid/never-loaded"
+            }
+          ],
+          "credentialSubject": {
+            "id": "did:example:6789",
+            "type": "Person"
+          }
+        }))
+        .unwrap();
+
+        let mut context_loader = ssi_json_ld::ContextLoader::default();
+        let vres = credential
+            .check_status(&DIDExample, &mut context_loader)
+            .await;
+        println!("{:#?}", vres);
+
+        // Exactly one revocation error from the first entry,
+        // exactly one structured status row, and the second
+        // entry's nope.invalid URL did not get touched.
+        assert_eq!(vres.errors.len(), 1);
+        assert!(vres.errors[0].contains("revoked"));
+        assert_eq!(vres.status.len(), 1);
+        assert!(vres.status[0].is_set);
+        assert_eq!(vres.status[0].status_purpose, "revocation");
     }
 
     #[async_std::test]

--- a/ssi-vc/src/revocation.rs
+++ b/ssi-vc/src/revocation.rs
@@ -13,7 +13,7 @@ use ssi_json_ld::{
     ContextLoader, CREDENTIALS_STATUS_V1_CONTEXT, REVOCATION_LIST_2020_V1_CONTEXT,
     STATUS_LIST_2021_V1_CONTEXT,
 };
-use ssi_ldp::VerificationResult;
+use ssi_ldp::{StatusCheckEntry, VerificationResult};
 use thiserror::Error;
 
 #[allow(clippy::upper_case_acronyms)]
@@ -623,6 +623,18 @@ impl CredentialStatus for RevocationList2020Status {
                     .with_error("Credential index in revocation list is invalid.".to_string());
             }
         };
+
+        // Structured outcome. RevocationList2020 doesn't carry a
+        // status_purpose field, so we synthesize "revocation" — that's
+        // the only purpose this entry type ever expressed.
+        result.status.push(StatusCheckEntry {
+            entry_type: "RevocationList2020Status".to_string(),
+            status_purpose: "revocation".to_string(),
+            is_set: revoked,
+            status_list_credential: Some(self.revocation_list_credential.clone()),
+            status_list_index: Some(self.revocation_list_index.0.to_string()),
+        });
+
         if revoked {
             return result.with_error("Credential is revoked.".to_string());
         }
@@ -748,8 +760,28 @@ impl CredentialStatus for StatusList2021Entry {
                     .with_error("Credential index in revocation list is invalid.".to_string());
             }
         };
+
+        // Mirror the BitstringStatusListEntry path: emit a structured
+        // entry alongside the (possibly empty) error so consumers can
+        // distinguish revoked / suspended / active without parsing
+        // the human-readable error text.
+        result.status.push(StatusCheckEntry {
+            entry_type: "StatusList2021Entry".to_string(),
+            status_purpose: self.status_purpose.clone(),
+            is_set: revoked,
+            status_list_credential: Some(self.status_list_credential.clone()),
+            status_list_index: Some(self.status_list_index.0.to_string()),
+        });
+
         if revoked {
-            return result.with_error("Credential is revoked.".to_string());
+            return match self.status_purpose.as_str() {
+                "revocation" => result.with_error("Credential is revoked.".to_string()),
+                "suspension" => result.with_error("Credential is suspended.".to_string()),
+                status_purpose => result.with_error(format!(
+                    "Credential status is set for purpose: {}",
+                    status_purpose
+                )),
+            };
         }
         result
     }
@@ -901,6 +933,19 @@ impl CredentialStatus for BitstringStatusListEntry {
                     .with_error("Credential index in status list is invalid.".to_string());
             }
         };
+
+        // Record the structured outcome before deciding whether to
+        // attach an error. Downstream consumers can read
+        // `result.status` for an unambiguous purpose+is_set result
+        // without parsing the human-readable error string.
+        result.status.push(StatusCheckEntry {
+            entry_type: "BitstringStatusListEntry".to_string(),
+            status_purpose: self.status_purpose.clone(),
+            is_set: status,
+            status_list_credential: Some(self.status_list_credential.clone()),
+            status_list_index: Some(self.status_list_index.0.to_string()),
+        });
+
         if status {
             return match self.status_purpose.as_str() {
                 "revocation" => result.with_error("Credential is revoked.".to_string()),


### PR DESCRIPTION
Two related fixes to `credentialStatus` handling, both required by LearnCard's OpenID4VC verification flow but generally useful to any consumer that wants to render structured revocation/suspension UI:

1. **Deserialize `credentialStatus` as `OneOrMany<Status>`** so VC 2.0 credentials with multiple status entries (e.g. one `"revocation"` + one `"suspension"`) verify instead of failing with a serde error.
2. **Surface a structured per-entry result** on [VerificationResult](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:72:0-96:1) so callers no longer have to string-match `errors` to tell "revoked" from "suspended" from "active".

Both ship behind the existing [VerificationResult](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:72:0-96:1) JSON shape — additive, no consumer breakage.

---

## Motivation

Today, `Credential.credential_status: Option<Status>` rejects any VC whose `credentialStatus` is a JSON array, even though the VC 2.0 data model explicitly allows it (and several test vectors in the wild use it for `revocation` + `suspension` combos).

Separately, when a single status check *does* run, the only signal a caller gets is `result.errors[i]` containing a human string like `"credential is revoked"`. That forces every downstream UI (LearnCard's wallet, OpenID4VC verifier, etc.) to grep error strings to distinguish "revoked", "suspended", and "the status check itself failed", and gives no way to say "this credential is *actively* not revoked" — only the absence of an error.

LearnCard is moving its OpenID4VC plugin off a hand-rolled status-list plugin and onto didkit's built-in BitstringStatusList support, and these two gaps are the last things blocking that migration.

---

## Changes

### [ssi-vc/src/lib.rs](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/lib.rs:0:0-0:0)

- **Type change:** `Credential.credential_status: Option<Status>` → `Option<OneOrMany<Status>>`. `OneOrMany`'s serde impl already accepts both a single object and an array, so wire-level backwards compatibility is preserved for the `One` case.
- **[Credential::check_status](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/lib.rs:1162:4-1225:5):** rewritten to iterate every entry in the `OneOrMany`, run each [CredentialStatus::check](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/lib.rs:1297:4-1308:5), and aggregate the per-entry [VerificationResult](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:72:0-96:1)s (errors, warnings, **and** the new `status` vec) into a single result. Short-circuits on the first per-entry hard failure to preserve existing behaviour.
- **Tests added:**
  - Status entry as array (multi-entry purpose split): both purposes are checked, both contribute structured entries.
  - Short-circuit-on-revoked: a revoked entry stops further entries from being fetched (preserves today's contract).
  - Single-entry round-trip: existing single-object form still parses and produces exactly one structured entry.
  - Re-asserts on the existing [BitstringStatusListEntry](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/revocation.rs:74:0-92:1), [StatusList2021Entry](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/revocation.rs:51:0-67:1), and [RevocationList2020Status](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/revocation.rs:36:0-44:1) tests to lock in the structured field on the active and revoked branches.

### [ssi-ldp/src/lib.rs](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:0:0-0:0)

- New public type `StatusCheckEntry { entry_type, status_purpose, is_set, status_list_credential, status_list_index }` — `Serialize`/`Deserialize`/`Clone`/`Debug`.
- [VerificationResult](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:72:0-96:1) gains `pub status: Vec<StatusCheckEntry>`, decorated with `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so older clients that don't know about the field continue to round-trip the old shape exactly.
- New helper [VerificationResult::with_status(...)](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:158:4-163:5) mirroring the existing [with_error](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:153:4-156:5) / `with_warning` ergonomics, plus an updated `Default` impl.

### [ssi-vc/src/revocation.rs](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/revocation.rs:0:0-0:0)

All three [CredentialStatus](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/lib.rs:237:0-244:1) impls now push a [StatusCheckEntry](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:107:0-130:1) alongside their existing error reporting:

- [BitstringStatusListEntry::check](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/lib.rs:1297:4-1308:5)
- [StatusList2021Entry::check](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/lib.rs:1297:4-1308:5)
- [RevocationList2020Status::check](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/lib.rs:1297:4-1308:5)

The entry is populated on both the "set" and "not set" paths, so an active credential produces an affirmative `isSet: false` rather than just an empty errors array.

---

## Wire format

[VerificationResult](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:72:0-96:1) JSON for an unrevoked VC 2.0 + BitstringStatusListEntry credential, before:

```json
{ "checks": ["proof", "status"], "warnings": [], "errors": [] }
```

After:

```json
{
  "checks": ["proof", "status"],
  "warnings": [],
  "errors": [],
  "status": [
    {
      "entryType": "BitstringStatusListEntry",
      "statusPurpose": "revocation",
      "isSet": false,
      "statusListCredential": "https://example.com/status/1",
      "statusListIndex": "94567"
    }
  ]
}
```

Revoked case: same shape, `isSet: true`, plus the existing `"credential is revoked"` string in `errors` (preserved for backwards compatibility).

Credentials with no `credentialStatus` at all: `status` field is omitted entirely (`skip_serializing_if`), so the JSON is byte-identical to the pre-PR output.

---

## Backwards compatibility

| Consumer | Behaviour |
|---|---|
| Old client reading new JSON | `status` is unknown — ignored by serde. |
| New client reading old JSON | `status` is [default](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/revocation.rs:387:4-390:5) (empty vec) — [Vec::is_empty()](cci:1://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-vc/src/lib.rs:137:4-149:5) ⇒ "no structured info available". |
| Existing single-entry credentials | Unchanged: serde `OneOrMany::One` → existing path → one entry in the new vec. |
| Existing array-form credentials | Previously rejected with a deserialize error; now verified. |

---

## Test plan

- `cargo test -p ssi-vc` — covers all three status-list flavours in active + revoked + array + short-circuit configurations.
- Integration: LearnCard's `@learncard/types` PR (`structured-status-check` changeset) adds the matching TypeScript surface, and the [bitstring-status-list.spec.ts](cci:7://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/tests/e2e/tests/bitstring-status-list.spec.ts:0:0-0:0) e2e in the LearnCard monorepo asserts the structured field end-to-end against didkit's WASM build.

---

## Linked work

- LearnCard monorepo: branch `lc-17-94-status` (adds [StatusCheckEntry](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:107:0-130:1) to `@learncard/types`, removes the now-redundant `@learncard/status-list-plugin`, asserts the new field in the bitstring e2e).
- didkit: no Rust change required — references `ssi` by relative path and re-exports [VerificationResult](cci:2://file:///Users/jackson/Documents/Projects/LEStudios/lc-clones/lc-2/LC-2/lib/ssi/ssi-ldp/src/lib.rs:72:0-96:1) unchanged, so the new field flows through serde automatically once didkit's WASM is rebuilt against this commit.

