### PR TITLE
Fix EdDSA Data Integrity interoperability

### DIFF
--- a/contexts/src/lib.rs
+++ b/contexts/src/lib.rs
@@ -36,6 +36,8 @@ pub const W3ID_ED2020_V1: &str = include_str!("../w3id-ed25519-signature-2020-v1
 pub const W3ID_MULTIKEY_V1: &str = include_str!("../w3id-multikey-v1.jsonld");
 /// <https://w3id.org/security/data-integrity/v1>
 pub const W3ID_DATA_INTEGRITY_V1: &str = include_str!("../w3id-data-integrity-v1.jsonld");
+/// <https://w3id.org/security/data-integrity/v2>
+pub const W3ID_DATA_INTEGRITY_V2: &str = include_str!("../w3id-data-integrity-v2.jsonld");
 /// <https://w3id.org/security/suites/blockchain-2021/v1>
 pub const BLOCKCHAIN2021_V1: &str = include_str!("../w3id-blockchain-2021-v1.jsonld");
 /// <https://w3id.org/citizenship/v1>

--- a/contexts/w3id-data-integrity-v2.jsonld
+++ b/contexts/w3id-data-integrity-v2.jsonld
@@ -1,0 +1,81 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "@protected": true,
+    "proof": {
+      "@id": "https://w3id.org/security#proof",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "DataIntegrityProof": {
+      "@id": "https://w3id.org/security#DataIntegrityProof",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "nonce": "https://w3id.org/security#nonce",
+        "previousProof": {
+          "@id": "https://w3id.org/security#previousProof",
+          "@type": "@id"
+        },
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "cryptosuite": {
+          "@id": "https://w3id.org/security#cryptosuite",
+          "@type": "https://w3id.org/security#cryptosuiteString"
+        },
+        "proofValue": {
+          "@id": "https://w3id.org/security#proofValue",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/ssi-json-ld/Cargo.toml
+++ b/ssi-json-ld/Cargo.toml
@@ -18,6 +18,7 @@ rdf-types = "0.12.15"
 locspan = "0.7.13"
 json-syntax = "0.9"
 futures = "0.3"
+serde_json = "1.0.95"
 lazy_static = "1.4"
 combination = "0.1"
 grdf = "0.16.2"
@@ -27,5 +28,4 @@ ssi-crypto = { path = "../ssi-crypto", version = "0.1" }
 [dev-dependencies]
 difference = "2.0"
 nquads-syntax = "0.10.0"
-serde_json = "1.0.95"
 tokio = { version = "1.27.0", features = ["rt", "macros"] }

--- a/ssi-json-ld/src/lib.rs
+++ b/ssi-json-ld/src/lib.rs
@@ -20,14 +20,20 @@ use thiserror::Error;
 /// Remote JSON-LD document.
 pub type RemoteDocument = json_ld::RemoteDocument<IriBuf, Span>;
 
-/// Error raised by the `json_to_dataset` function.
-pub type ToRdfError<
+/// Error raised by the [`json_to_dataset`] function.
+#[derive(Debug, Error)]
+pub enum ToRdfError<
     E = UnknownContext,
     C = json_ld::loader::ContextLoaderError<
         UnknownContext,
         Meta<json_ld::loader::ExtractContextError<Span>, Span>,
     >,
-> = json_ld::ToRdfError<Span, E, C>;
+> {
+    #[error(transparent)]
+    Processing(json_ld::ToRdfError<Span, E, C>),
+    #[error("DATA_LOSS_DETECTION_ERROR: {0}")]
+    DataLoss(String),
+}
 
 pub const CREDENTIALS_V1_CONTEXT: Iri = iri!("https://www.w3.org/2018/credentials/v1");
 pub const CREDENTIALS_V2_CONTEXT: Iri = iri!("https://www.w3.org/ns/credentials/v2");
@@ -55,6 +61,7 @@ pub const W3ID_JWS2020_V1_CONTEXT: Iri = iri!("https://w3id.org/security/suites/
 pub const W3ID_ED2020_V1_CONTEXT: Iri = iri!("https://w3id.org/security/suites/ed25519-2020/v1");
 pub const W3ID_MULTIKEY_V1_CONTEXT: Iri = iri!("https://w3id.org/security/multikey/v1");
 pub const W3ID_DATA_INTEGRITY_V1_CONTEXT: Iri = iri!("https://w3id.org/security/data-integrity/v1");
+pub const W3ID_DATA_INTEGRITY_V2_CONTEXT: Iri = iri!("https://w3id.org/security/data-integrity/v2");
 pub const BLOCKCHAIN2021_V1_CONTEXT: Iri =
     iri!("https://w3id.org/security/suites/blockchain-2021/v1");
 pub const CITIZENSHIP_V1_CONTEXT: Iri = iri!("https://w3id.org/citizenship/v1");
@@ -194,6 +201,10 @@ lazy_static::lazy_static! {
     pub static ref W3ID_DATA_INTEGRITY_V1_CONTEXT_DOCUMENT: RemoteDocument = load_static_context(
         W3ID_DATA_INTEGRITY_V1_CONTEXT,
         ssi_contexts::W3ID_DATA_INTEGRITY_V1
+    );
+    pub static ref W3ID_DATA_INTEGRITY_V2_CONTEXT_DOCUMENT: RemoteDocument = load_static_context(
+        W3ID_DATA_INTEGRITY_V2_CONTEXT,
+        ssi_contexts::W3ID_DATA_INTEGRITY_V2
     );
     pub static ref BLOCKCHAIN2021_V1_CONTEXT_DOCUMENT: RemoteDocument = load_static_context(
         BLOCKCHAIN2021_V1_CONTEXT,
@@ -396,6 +407,7 @@ impl Loader<IriBuf, Span> for StaticLoader {
                     W3ID_ED2020_V1_CONTEXT => Ok(W3ID_ED2020_V1_CONTEXT_DOCUMENT.clone()),
                     W3ID_MULTIKEY_V1_CONTEXT => Ok(W3ID_MULTIKEY_V1_CONTEXT_DOCUMENT.clone()),
                     W3ID_DATA_INTEGRITY_V1_CONTEXT => Ok(W3ID_DATA_INTEGRITY_V1_CONTEXT_DOCUMENT.clone()),
+                    W3ID_DATA_INTEGRITY_V2_CONTEXT => Ok(W3ID_DATA_INTEGRITY_V2_CONTEXT_DOCUMENT.clone()),
                     BLOCKCHAIN2021_V1_CONTEXT => Ok(BLOCKCHAIN2021_V1_CONTEXT_DOCUMENT.clone()),
                     CITIZENSHIP_V1_CONTEXT => Ok(CITIZENSHIP_V1_CONTEXT_DOCUMENT.clone()),
                     VACCINATION_V1_CONTEXT => Ok(VACCINATION_V1_CONTEXT_DOCUMENT.clone()),
@@ -601,9 +613,38 @@ pub enum ContextError {
     InvalidContext(#[from] Meta<json_ld::syntax::context::InvalidContext, Span>),
 }
 
+fn unwrap_context_documents(value: &mut serde_json::Value) -> bool {
+    let serde_json::Value::Array(contexts) = value else {
+        return false;
+    };
+    let mut changed = false;
+
+    for context in contexts {
+        let serde_json::Value::Object(object) = context else {
+            continue;
+        };
+
+        if object.len() != 1 || !object.contains_key("@context") {
+            continue;
+        }
+
+        *context = object.remove("@context").unwrap();
+        changed = true;
+    }
+
+    changed
+}
+
 /// Parse a JSON-LD context.
 pub fn parse_ld_context(content: &str) -> Result<RemoteContextReference, ContextError> {
     let json = json_syntax::Value::parse_str(content, |span| span)?;
+    let mut normalized: serde_json::Value =
+        serde_json::from_str(content).expect("json-syntax already validated the input");
+    let json = if unwrap_context_documents(&mut normalized) {
+        json_syntax::to_value_with(normalized, Span::default).unwrap()
+    } else {
+        json
+    };
     let context = json_ld::syntax::context::Value::try_from_json(json)?;
     Ok(RemoteContextReference::Loaded(RemoteContext::new(
         None, None, context,
@@ -645,7 +686,29 @@ where
     let mut to_rdf = doc
         .to_rdf_using(&mut generator, loader, options)
         .await
-        .map_err(Box::new)?;
+        .map_err(|error| {
+            Box::new(
+                if error.code() == json_ld::syntax::ErrorCode::KeyExpansionFailed {
+                    ToRdfError::DataLoss("undefined JSON-LD term".to_string())
+                } else {
+                    ToRdfError::Processing(error)
+                },
+            )
+        })?;
+
+    if let Some(term) = to_rdf
+        .document()
+        .traverse()
+        .filter_map(|fragment| fragment.into_id())
+        .find_map(|id| match id {
+            json_ld::Id::Invalid(term) if !term.is_empty() => Some(term),
+            json_ld::Id::Invalid(_) | json_ld::Id::Valid(_) => None,
+        })
+    {
+        return Err(Box::new(ToRdfError::DataLoss(format!(
+            "undefined JSON-LD term or relative IRI `{term}`"
+        ))));
+    }
     Ok(to_rdf
         .cloned_quads()
         .map(|q| {
@@ -805,5 +868,86 @@ mod test {
         );
 
         let _doc = result.unwrap();
+    }
+    #[tokio::test]
+    async fn rejects_json_ld_data_loss() {
+        let inputs = [
+            json!({
+                "@context": ["https://www.w3.org/2018/credentials/v1"],
+                "type": ["VerifiableCredential", "InvalidType"],
+                "issuer": "did:example:issuer",
+                "issuanceDate": "2020-03-16T22:37:26Z",
+                "credentialSubject": { "id": "did:example:subject" }
+            }),
+            json!({
+                "@context": ["https://www.w3.org/2018/credentials/v1"],
+                "type": ["VerifiableCredential"],
+                "issuer": "did:example:issuer",
+                "issuanceDate": "2020-03-16T22:37:26Z",
+                "credentialSubject": {
+                    "id": "did:example:subject",
+                    "invalidTerm": "invalidTerm"
+                }
+            }),
+        ];
+
+        for input in inputs {
+            let input = syntax::to_value_with(input, Default::default()).unwrap();
+            let error = json_to_dataset(input, &mut ContextLoader::default(), None)
+                .await
+                .unwrap_err();
+
+            assert!(
+                error.to_string().starts_with("DATA_LOSS_DETECTION_ERROR:"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn expands_cryptosuite_as_typed_string() {
+        let input = syntax::to_value_with(
+            json!({
+                "@context": [
+                    "https://www.w3.org/2018/credentials/v1",
+                    "https://w3id.org/security/data-integrity/v2"
+                ],
+                "type": "DataIntegrityProof",
+                "cryptosuite": "eddsa-rdfc-2022"
+            }),
+            Default::default(),
+        )
+        .unwrap();
+        let dataset = json_to_dataset(input, &mut ContextLoader::default(), None)
+            .await
+            .unwrap();
+
+        assert!(dataset.iter().any(|quad| {
+            matches!(
+                quad.object(),
+                rdf_types::Object::Literal(rdf_types::Literal::TypedString(value, ty))
+                    if value.as_str() == "eddsa-rdfc-2022"
+                        && ty.as_str() == "https://w3id.org/security#cryptosuiteString"
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn expands_minimal_v2_credential() {
+        let input = syntax::to_value_with(
+            json!({
+                "@context": ["https://www.w3.org/ns/credentials/v2"],
+                "type": ["VerifiableCredential"],
+                "issuer": "did:example:issuer",
+                "validFrom": "2023-01-01T00:00:00Z",
+                "credentialSubject": { "id": "did:example:subject" }
+            }),
+            Default::default(),
+        )
+        .unwrap();
+
+        json_to_dataset(input, &mut ContextLoader::default(), None)
+            .await
+            .unwrap();
     }
 }

--- a/ssi-ldp/src/proof.rs
+++ b/ssi-ldp/src/proof.rs
@@ -9,6 +9,7 @@ use super::*;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use ssi_core::one_or_many::OneOrMany;
 use ssi_dids::did_resolve::DIDResolver;
 use ssi_dids::VerificationRelationship as ProofPurpose;
 use ssi_json_ld::{json_to_dataset, parse_ld_context, ContextLoader};
@@ -36,6 +37,8 @@ pub struct Proof {
     // TODO: use consistent types for context
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub context: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     #[serde(rename = "type")]
     pub type_: ProofSuiteType,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -61,6 +64,9 @@ pub struct Proof {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cryptosuite: Option<dataintegrity::DataIntegrityCryptoSuite>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "previousProof")]
+    pub previous_proof: Option<OneOrMany<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(flatten)]
     pub property_set: Option<Map<String, Value>>,
 }
@@ -70,6 +76,7 @@ impl Proof {
         Self {
             type_,
             context: Value::default(),
+            id: None,
             proof_purpose: None,
             proof_value: None,
             challenge: None,
@@ -81,6 +88,7 @@ impl Proof {
             jws: None,
             property_set: None,
             cryptosuite: None,
+            previous_proof: None,
         }
     }
 
@@ -449,6 +457,11 @@ fn verify_proof_consistency(
             .map(|cc| cc.to_string())
             .as_deref(),
     )?;
+    graph_ref.take_objects_and_assert_eq_iris(
+        proof_id,
+        iri!("https://w3id.org/security#previousProof"),
+        proof.previous_proof.as_ref(),
+    )?;
 
     graph_ref.take_object_and_assert_eq_iri(
         proof_id,
@@ -661,6 +674,51 @@ trait ProofGraph:
         })
     }
 
+    /// Takes every statement matching `s p ?` and checks that its IRI objects
+    /// equal the expected unordered set.
+    fn take_objects_and_assert_eq_iris(
+        &mut self,
+        s: &Self::Subject,
+        p: Iri,
+        expected_o: Option<&OneOrMany<String>>,
+    ) -> Result<(), Box<ProofInconsistency>> {
+        let mut actual = Vec::new();
+
+        while let Some(rdf_types::Triple(_, _, object)) =
+            self.take_match(rdf_types::Triple(Some(s), Some(&p), None))
+        {
+            match object {
+                rdf_types::Term::Iri(iri) => actual.push(iri.to_string()),
+                object => {
+                    return Err(Box::new(ProofInconsistency::ObjectMismatch(
+                        p.to_owned(),
+                        "IRI".to_string(),
+                        object.to_string(),
+                    )))
+                }
+            }
+        }
+
+        let mut expected: Vec<String> = expected_o
+            .into_iter()
+            .flatten()
+            .map(ToString::to_string)
+            .collect();
+
+        actual.sort_unstable();
+        expected.sort_unstable();
+
+        if actual == expected {
+            Ok(())
+        } else {
+            Err(Box::new(ProofInconsistency::ObjectMismatch(
+                p.to_owned(),
+                format!("{expected:?}"),
+                format!("{actual:?}"),
+            )))
+        }
+    }
+
     /// When `expected_o` is `Some(iri)`.
     /// take any statement of the form `s p o` for the given `s` and `p`
     /// and checks that `o` is equal to `iri`.
@@ -745,8 +803,9 @@ impl ProofGraph for grdf::HashGraph<rdf_types::Subject, IriBuf, rdf_types::Objec
             rdf_types::Object::Iri(iri) => iri.as_str() == *expected,
             rdf_types::Object::Literal(rdf_types::Literal::String(s)) => s.as_str() == *expected,
             // Handle typed literals with cryptosuite datatype (fixes DataIntegrity proof serialization)
-            rdf_types::Object::Literal(rdf_types::Literal::TypedString(s, ty)) 
-                if *ty == iri!("https://w3id.org/security#cryptosuiteString") => {
+            rdf_types::Object::Literal(rdf_types::Literal::TypedString(s, ty))
+                if *ty == iri!("https://w3id.org/security#cryptosuiteString") =>
+            {
                 s.as_str() == *expected
             }
             _ => false,

--- a/ssi-ldp/src/suites/dataintegrity.rs
+++ b/ssi-ldp/src/suites/dataintegrity.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssi_dids::did_resolve::{resolve_key, DIDResolver};
-use ssi_json_ld::{ContextLoader, CREDENTIALS_V2_CONTEXT, W3ID_DATA_INTEGRITY_V1_CONTEXT};
+use ssi_json_ld::{
+    ContextLoader, CREDENTIALS_V2_CONTEXT, W3ID_DATA_INTEGRITY_V1_CONTEXT,
+    W3ID_DATA_INTEGRITY_V2_CONTEXT,
+};
 use ssi_jwk::{Algorithm, Base64urlUInt, JWK};
 use ssi_jws::VerificationWarnings;
 
@@ -158,8 +161,9 @@ impl DataIntegrityProof {
         proof.cryptosuite = Some(cryptosuite.clone());
         if !document_has_context(document, CREDENTIALS_V2_CONTEXT)?
             && !document_has_context(document, W3ID_DATA_INTEGRITY_V1_CONTEXT)?
+            && !document_has_context(document, W3ID_DATA_INTEGRITY_V2_CONTEXT)?
         {
-            proof.context = serde_json::json!([W3ID_DATA_INTEGRITY_V1_CONTEXT]);
+            proof.context = serde_json::json!([W3ID_DATA_INTEGRITY_V2_CONTEXT]);
         }
         let message =
             Self::jws_payload(&cryptosuite, &jwa, &proof, document, context_loader).await?;

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -44,8 +44,343 @@ use serde_json::Value;
 // - Support normalization of arbitrary JSON-LD
 // - Support more LD-proof types
 
+const PROOF_VERIFICATION_ERROR: &str = "PROOF_VERIFICATION_ERROR";
+
+struct ProofDependencyGraph {
+    dependencies: Vec<Vec<usize>>,
+}
+
+impl ProofDependencyGraph {
+    fn new(proofs: &[&Proof]) -> Result<Option<Self>, String> {
+        if !proofs.iter().any(|proof| proof.previous_proof.is_some()) {
+            return Ok(None);
+        }
+
+        let mut proof_ids = Map::new();
+
+        for (index, proof) in proofs.iter().enumerate() {
+            let Some(id) = proof.id.as_ref() else {
+                continue;
+            };
+
+            if id.is_empty() {
+                return Err(format!(
+                    "{PROOF_VERIFICATION_ERROR}: proof id must not be empty"
+                ));
+            }
+
+            if proof_ids.insert(id.as_str(), index).is_some() {
+                return Err(format!(
+                    "{PROOF_VERIFICATION_ERROR}: duplicate proof id `{id}`"
+                ));
+            }
+        }
+
+        let mut dependencies = vec![Vec::new(); proofs.len()];
+
+        for (index, proof) in proofs.iter().enumerate() {
+            let Some(previous_proofs) = proof.previous_proof.as_ref() else {
+                continue;
+            };
+
+            if previous_proofs.is_empty() {
+                return Err(format!(
+                    "{PROOF_VERIFICATION_ERROR}: previousProof must not be empty"
+                ));
+            }
+
+            for previous_id in previous_proofs {
+                let Some(previous_index) = proof_ids.get(previous_id.as_str()) else {
+                    return Err(format!(
+                        "{PROOF_VERIFICATION_ERROR}: previousProof `{previous_id}` does not identify another proof"
+                    ));
+                };
+
+                dependencies[index].push(*previous_index);
+            }
+        }
+
+        let graph = Self { dependencies };
+        let mut states = vec![0; proofs.len()];
+
+        for index in 0..proofs.len() {
+            graph.visit(index, &mut states, &mut Vec::new())?;
+        }
+
+        Ok(Some(graph))
+    }
+
+    fn ordered_dependencies(&self, index: usize) -> Result<Vec<usize>, String> {
+        let mut states = vec![0; self.dependencies.len()];
+        let mut order = Vec::new();
+
+        self.visit(index, &mut states, &mut order)?;
+
+        Ok(order)
+    }
+
+    fn visit(&self, index: usize, states: &mut [u8], order: &mut Vec<usize>) -> Result<(), String> {
+        match states[index] {
+            1 => {
+                return Err(format!(
+                    "{PROOF_VERIFICATION_ERROR}: cyclic previousProof dependency"
+                ))
+            }
+            2 => return Ok(()),
+            _ => {}
+        }
+
+        states[index] = 1;
+
+        for dependency in &self.dependencies[index] {
+            self.visit(*dependency, states, order)?;
+        }
+
+        states[index] = 2;
+        order.push(index);
+
+        Ok(())
+    }
+}
+/// Signing input used by W3C proof-chain fixtures that commit each proof to its predecessors.
+/// Standard proof-free document verification is attempted before this compatibility form.
+struct ProofChainDocument {
+    value: Value,
+    contexts: Option<String>,
+    default_proof_purpose: Option<ProofPurpose>,
+    issuer: Option<String>,
+}
+
+impl ProofChainDocument {
+    fn new(
+        document: &(dyn LinkedDataDocument + Sync),
+        predecessors: &[&Proof],
+    ) -> Result<Self, String> {
+        let mut value = document.to_value().map_err(|error| error.to_string())?;
+        let object = value.as_object_mut().ok_or_else(|| {
+            format!("{PROOF_VERIFICATION_ERROR}: secured document must be an object")
+        })?;
+
+        match predecessors {
+            [] => {
+                object.remove("proof");
+            }
+            [proof] => {
+                object.insert(
+                    "proof".to_string(),
+                    serde_json::to_value(proof).map_err(|error| error.to_string())?,
+                );
+            }
+            proofs => {
+                object.insert(
+                    "proof".to_string(),
+                    serde_json::to_value(proofs).map_err(|error| error.to_string())?,
+                );
+            }
+        }
+
+        // Some W3C fixtures embed a context document as an inline context entry. Normalize only
+        // this compatibility copy; the credential's parsed and serialized representation is unchanged.
+        if let Some(contexts) = object.get_mut("@context").and_then(Value::as_array_mut) {
+            for context in contexts {
+                let Value::Object(context_document) = context else {
+                    continue;
+                };
+
+                if context_document.len() == 1 {
+                    if let Some(inner) = context_document.remove("@context") {
+                        *context = inner;
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            value,
+            contexts: document.get_contexts().map_err(|error| error.to_string())?,
+            default_proof_purpose: document.get_default_proof_purpose(),
+            issuer: document.get_issuer().map(str::to_string),
+        })
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl LinkedDataDocument for ProofChainDocument {
+    fn get_contexts(&self) -> Result<Option<String>, LdpError> {
+        Ok(self.contexts.clone())
+    }
+
+    fn to_value(&self) -> Result<Value, LdpError> {
+        Ok(self.value.clone())
+    }
+
+    fn get_default_proof_purpose(&self) -> Option<ProofPurpose> {
+        self.default_proof_purpose.clone()
+    }
+
+    fn get_issuer(&self) -> Option<&str> {
+        self.issuer.as_deref()
+    }
+
+    async fn to_dataset_for_signing(
+        &self,
+        parent: Option<&(dyn LinkedDataDocument + Sync)>,
+        context_loader: &mut ContextLoader,
+    ) -> Result<DataSet, LdpError> {
+        let json =
+            ssi_json_ld::syntax::to_value_with(self.value.clone(), || Default::default()).unwrap();
+
+        Ok(json_to_dataset(
+            json,
+            context_loader,
+            parent
+                .map(LinkedDataDocument::get_contexts)
+                .transpose()?
+                .flatten()
+                .as_deref()
+                .map(parse_ld_context)
+                .transpose()?,
+        )
+        .await?)
+    }
+}
+
+async fn verify_proof_candidates(
+    document: &(dyn LinkedDataDocument + Sync),
+    proof_set: Option<&OneOrMany<Proof>>,
+    candidates: Vec<&Proof>,
+    resolver: &dyn DIDResolver,
+    context_loader: &mut ContextLoader,
+) -> VerificationResult {
+    let all_proofs: Vec<&Proof> = proof_set.into_iter().flatten().collect();
+    let graph = match ProofDependencyGraph::new(&all_proofs) {
+        Ok(graph) => graph,
+        Err(error) => return VerificationResult::error(&error),
+    };
+    let Some(graph) = graph else {
+        let mut failures = VerificationResult::new();
+
+        for proof in candidates {
+            let mut result = proof.verify(document, resolver, context_loader).await;
+            let succeeded = result.errors.is_empty();
+
+            if succeeded {
+                result.checks.push(Check::Proof);
+
+                return result;
+            }
+
+            failures.append(&mut result);
+        }
+
+        return failures;
+    };
+
+    let candidate_count = candidates.len();
+    let candidate_indices: Vec<usize> = candidates
+        .iter()
+        .filter_map(|candidate| {
+            all_proofs
+                .iter()
+                .position(|proof| std::ptr::eq(*proof, *candidate))
+        })
+        .collect();
+
+    if candidate_indices.len() != candidate_count {
+        return VerificationResult::error(&format!(
+            "{PROOF_VERIFICATION_ERROR}: candidate proof is not present in allProofs"
+        ));
+    }
+
+    let mut referenced_by_candidate = vec![false; all_proofs.len()];
+
+    for candidate in &candidate_indices {
+        let ancestors = match graph.ordered_dependencies(*candidate) {
+            Ok(ancestors) => ancestors,
+            Err(error) => return VerificationResult::error(&error),
+        };
+
+        for ancestor in ancestors {
+            if ancestor != *candidate && candidate_indices.contains(&ancestor) {
+                referenced_by_candidate[ancestor] = true;
+            }
+        }
+    }
+
+    let targets: Vec<usize> = candidate_indices
+        .into_iter()
+        .filter(|index| !referenced_by_candidate[*index])
+        .collect();
+
+    if targets.is_empty() {
+        return VerificationResult::error(&format!(
+            "{PROOF_VERIFICATION_ERROR}: no terminal proof"
+        ));
+    }
+
+    let mut failures = VerificationResult::new();
+
+    for target in targets {
+        let order = match graph.ordered_dependencies(target) {
+            Ok(order) => order,
+            Err(error) => return VerificationResult::error(&error),
+        };
+        let mut candidate_result = VerificationResult::new();
+        let mut succeeded = true;
+
+        for index in order {
+            let mut result = all_proofs[index]
+                .verify(document, resolver, context_loader)
+                .await;
+
+            // Current implementations sign against a proof-free document. W3C's proof-chain
+            // fixtures commit later proofs to their predecessor set, so retry that form only
+            // after standard verification fails.
+            if !result.errors.is_empty() {
+                let proof_order = match graph.ordered_dependencies(index) {
+                    Ok(proof_order) => proof_order,
+                    Err(error) => return VerificationResult::error(&error),
+                };
+                let predecessors: Vec<&Proof> = proof_order[..proof_order.len() - 1]
+                    .iter()
+                    .map(|proof_index| all_proofs[*proof_index])
+                    .collect();
+                let chain_document = match ProofChainDocument::new(document, &predecessors) {
+                    Ok(chain_document) => chain_document,
+                    Err(error) => return VerificationResult::error(&error),
+                };
+
+                result = all_proofs[index]
+                    .verify(&chain_document, resolver, context_loader)
+                    .await;
+            }
+            let proof_succeeded = result.errors.is_empty();
+
+            candidate_result.append(&mut result);
+
+            if !proof_succeeded {
+                succeeded = false;
+                break;
+            }
+        }
+
+        if succeeded {
+            candidate_result.checks.push(Check::Proof);
+
+            return candidate_result;
+        }
+
+        failures.append(&mut candidate_result);
+    }
+
+    failures
+}
+
 pub const DEFAULT_CONTEXT: &str = "https://www.w3.org/2018/credentials/v1";
 pub const DEFAULT_CONTEXT_V2: &str = "https://www.w3.org/ns/credentials/v2";
+pub const NON_DID_ISSUER_WARNING: &str =
+    "Issuer authorization was not checked because the credential issuer is not a DID";
 
 // work around https://github.com/w3c/vc-test-suite/issues/103
 pub const ALT_DEFAULT_CONTEXT: &str = "https://w3.org/2018/credentials/v1";
@@ -861,6 +1196,8 @@ impl Credential {
         }
         // TODO: error if any unconvertable claims
         // TODO: unify with verify function?
+        let warn_unchecked_issuer = vc.has_non_did_issuer();
+
         let (proofs, matched_jwt) = match vc
             .filter_proofs(options_opt, Some((&header, &claims)), resolver)
             .await
@@ -900,6 +1237,10 @@ impl Credential {
                     .errors
                     .push(format!("Unable to verify signature: {}", err)),
             }
+            if results.checks.contains(&Check::JWS) && warn_unchecked_issuer {
+                results.warnings.push(NON_DID_ISSUER_WARNING.to_string());
+            }
+
             return (Some(vc), results);
         }
         // No JWS verified: try to verify a proof.
@@ -909,18 +1250,15 @@ impl Credential {
                 VerificationResult::error("No applicable JWS or proof"),
             );
         }
-        // Try verifying each proof until one succeeds
-        for proof in proofs {
-            let mut result = proof.verify(&vc, resolver, context_loader).await;
-            results.append(&mut result);
-            if results.errors.is_empty() {
-                results.checks.push(Check::Proof);
-                break;
-            };
-        }
+        results =
+            verify_proof_candidates(&vc, vc.proof.as_ref(), proofs, resolver, context_loader).await;
         if checks.contains(&Check::Status) {
             results.append(&mut vc.check_status(resolver, context_loader).await);
         }
+        if results.checks.contains(&Check::Proof) && warn_unchecked_issuer {
+            results.warnings.push(NON_DID_ISSUER_WARNING.to_string());
+        }
+
         (Some(vc), results)
     }
 
@@ -978,30 +1316,48 @@ impl Credential {
         Ok(())
     }
 
+    fn has_non_did_issuer(&self) -> bool {
+        self.issuer
+            .as_ref()
+            .map(|issuer| !issuer.get_id().starts_with("did:"))
+            .unwrap_or(false)
+    }
+
     async fn filter_proofs<'a>(
         &'a self,
         options: Option<LinkedDataProofOptions>,
         jwt_params: Option<(&Header, &JWTClaims)>,
         resolver: &'a dyn DIDResolver,
     ) -> Result<(Vec<&'a Proof>, bool), String> {
-        // Allow any of issuer's verification methods by default
+        // Restrict proofs to the issuer's verification methods only when the
+        // issuer is a DID. URL issuers are valid in the VC data model, but do
+        // not have a DID document from which to derive an allowed VM set.
         let mut options = options.unwrap_or_default();
-        let allowed_vms = match options.verification_method.take() {
-            Some(vm) => vec![vm.to_string()],
+        let restrict_allowed_vms = match options.verification_method.take() {
+            Some(vm) => Some(vec![vm.to_string()]),
             None => {
-                if let Some(ref issuer) = self.issuer {
-                    let issuer_did = issuer.get_id();
-                    // https://w3c.github.io/did-core/#assertion
-                    // assertionMethod is the verification relationship usually used for issuing
-                    // VCs.
-                    let proof_purpose = options
-                        .proof_purpose
-                        .clone()
-                        .unwrap_or(ProofPurpose::AssertionMethod);
-                    get_verification_methods_for_purpose(&issuer_did, resolver, proof_purpose)
-                        .await?
+                if let Some(issuer) = &self.issuer {
+                    let issuer_id = issuer.get_id();
+
+                    if issuer_id.starts_with("did:") {
+                        let proof_purpose = options
+                            .proof_purpose
+                            .clone()
+                            .unwrap_or(ProofPurpose::AssertionMethod);
+
+                        Some(
+                            get_verification_methods_for_purpose(
+                                &issuer_id,
+                                resolver,
+                                proof_purpose,
+                            )
+                            .await?,
+                        )
+                    } else {
+                        None
+                    }
                 } else {
-                    Vec::new()
+                    None
                 }
             }
         };
@@ -1009,14 +1365,21 @@ impl Credential {
             .proof
             .iter()
             .flatten()
-            .filter(|proof| proof.matches(&options, &allowed_vms))
+            .filter(|proof| {
+                proof.matches_options(&options)
+                    && if let Some(allowed_vms) = &restrict_allowed_vms {
+                        proof.matches_vms(allowed_vms)
+                    } else {
+                        true
+                    }
+            })
             .collect();
         let matched_jwt = match jwt_params {
             Some((header, claims)) => jwt_matches(
                 header,
                 claims,
                 &options,
-                &Some(allowed_vms),
+                &restrict_allowed_vms,
                 &ProofPurpose::AssertionMethod,
             ),
             None => false,
@@ -1031,6 +1394,8 @@ impl Credential {
         resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
     ) -> VerificationResult {
+        let warn_unchecked_issuer = self.has_non_did_issuer();
+
         let checks = options
             .as_ref()
             .and_then(|opts| opts.checks.clone())
@@ -1045,16 +1410,9 @@ impl Credential {
             return VerificationResult::error("No applicable proof");
             // TODO: say why, e.g. expired
         }
-        let mut results = VerificationResult::new();
-        // Try verifying each proof until one succeeds
-        for proof in proofs {
-            let mut result = proof.verify(self, resolver, context_loader).await;
-            results.append(&mut result);
-            if result.errors.is_empty() {
-                results.checks.push(Check::Proof);
-                break;
-            };
-        }
+        let mut results =
+            verify_proof_candidates(self, self.proof.as_ref(), proofs, resolver, context_loader)
+                .await;
         if checks.contains(&Check::Status) {
             results.append(&mut self.check_status(resolver, context_loader).await);
         }
@@ -1062,6 +1420,10 @@ impl Credential {
         if checks.contains(&Check::Schema) {
             results.append(&mut self.check_schema(resolver, context_loader).await);
         }
+        if results.checks.contains(&Check::Proof) && warn_unchecked_issuer {
+            results.warnings.push(NON_DID_ISSUER_WARNING.to_string());
+        }
+
         results
     }
 
@@ -1124,22 +1486,20 @@ impl Credential {
                         Value::String(s) => Some(Context::URI(URI::String(s.clone()))),
                         Value::Object(obj) => {
                             // Convert serde_json::Map to HashMap
-                            let hashmap: HashMap<String, Value> = obj.iter()
-                                .map(|(k, v)| (k.clone(), v.clone()))
-                                .collect();
+                            let hashmap: HashMap<String, Value> =
+                                obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
                             Some(Context::Object(hashmap))
-                        },
+                        }
                         _ => None,
                     })
                     .collect()
             }
             Value::Object(obj) => {
                 // Convert serde_json::Map to HashMap
-                let hashmap: HashMap<String, Value> = obj.iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect();
+                let hashmap: HashMap<String, Value> =
+                    obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
                 vec![Context::Object(hashmap)]
-            },
+            }
             _ => return, // Skip invalid context values
         };
 
@@ -1187,28 +1547,24 @@ impl Credential {
             let status_value = match serde_json::to_value(entry.clone()) {
                 Ok(status) => status,
                 Err(e) => {
-                    result.errors.push(format!(
-                        "Unable to convert credentialStatus: {}",
-                        e
-                    ));
+                    result
+                        .errors
+                        .push(format!("Unable to convert credentialStatus: {}", e));
                     return result;
                 }
             };
 
-            let checkable_status: CheckableStatus =
-                match serde_json::from_value(status_value) {
-                    Ok(checkable_status) => checkable_status,
-                    Err(e) => {
-                        result.errors.push(format!(
-                            "Unable to parse credentialStatus: {}",
-                            e
-                        ));
-                        return result;
-                    }
-                };
+            let checkable_status: CheckableStatus = match serde_json::from_value(status_value) {
+                Ok(checkable_status) => checkable_status,
+                Err(e) => {
+                    result
+                        .errors
+                        .push(format!("Unable to parse credentialStatus: {}", e));
+                    return result;
+                }
+            };
 
-            let mut entry_result =
-                checkable_status.check(self, resolver, context_loader).await;
+            let mut entry_result = checkable_status.check(self, resolver, context_loader).await;
             result.append(&mut entry_result);
 
             // Stop on the first failing entry — the credential is
@@ -1615,15 +1971,8 @@ impl Presentation {
                 VerificationResult::error("No applicable JWS or proof"),
             );
         }
-        // Try verifying each proof until one succeeds
-        for proof in proofs {
-            let mut result = proof.verify(&vp, resolver, context_loader).await;
-            if result.errors.is_empty() {
-                result.checks.push(Check::Proof);
-                return (Some(vp), result);
-            };
-            results.append(&mut result);
-        }
+        results =
+            verify_proof_candidates(&vp, vp.proof.as_ref(), proofs, resolver, context_loader).await;
         (Some(vp), results)
     }
 
@@ -1720,19 +2069,18 @@ impl Presentation {
         // Convert proof context Value to Context objects
         let proof_contexts: Vec<Context> = match proof_context {
             Value::String(s) => vec![Context::URI(URI::String(s.clone()))],
-            Value::Array(arr) => {
-                arr.iter()
-                    .filter_map(|v| match v {
-                        Value::String(s) => Some(Context::URI(URI::String(s.clone()))),
-                        Value::Object(obj) => {
-                            let hashmap: HashMap<String, Value> =
-                                obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                            Some(Context::Object(hashmap))
-                        }
-                        _ => None,
-                    })
-                    .collect()
-            }
+            Value::Array(arr) => arr
+                .iter()
+                .filter_map(|v| match v {
+                    Value::String(s) => Some(Context::URI(URI::String(s.clone()))),
+                    Value::Object(obj) => {
+                        let hashmap: HashMap<String, Value> =
+                            obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                        Some(Context::Object(hashmap))
+                    }
+                    _ => None,
+                })
+                .collect(),
             Value::Object(obj) => {
                 let hashmap: HashMap<String, Value> =
                     obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
@@ -1801,15 +2149,13 @@ impl Presentation {
             })
             .collect();
         let matched_jwt = match jwt_params {
-            Some((header, claims)) => {
-                jwt_matches(
-                    header,
-                    claims,
-                    &options,
-                    &restrict_allowed_vms,
-                    &ProofPurpose::Authentication,
-                )
-            },
+            Some((header, claims)) => jwt_matches(
+                header,
+                claims,
+                &options,
+                &restrict_allowed_vms,
+                &ProofPurpose::Authentication,
+            ),
             None => false,
         };
         Ok((matched_proofs, matched_jwt))
@@ -1832,7 +2178,7 @@ impl Presentation {
                 "credentialStatus check not valid for VerifiablePresentation",
             );
         }
-        let mut results = VerificationResult::new();
+        let results;
         let (proofs, _) = match self.filter_proofs(options, None, resolver).await {
             Ok(proofs) => proofs,
             Err(err) => {
@@ -1843,15 +2189,9 @@ impl Presentation {
             return VerificationResult::error("No applicable proof");
             // TODO: say why, e.g. expired
         }
-        // Try verifying each proof until one succeeds
-        for proof in proofs {
-            let mut result = proof.verify(self, resolver, context_loader).await;
-            if result.errors.is_empty() {
-                result.checks.push(Check::Proof);
-                return result;
-            };
-            results.append(&mut result);
-        }
+        results =
+            verify_proof_candidates(self, self.proof.as_ref(), proofs, resolver, context_loader)
+                .await;
         results
     }
 
@@ -2106,6 +2446,42 @@ pub(crate) mod tests {
     use ssi_json_ld::urdna2015;
     use ssi_jws::sign_bytes_b64;
     use ssi_ldp::{ProofSuite, ProofSuiteType};
+
+    #[async_std::test]
+    async fn allows_did_verification_method_for_url_issuer() {
+        let credential = Credential::from_json(
+            r#"{
+                "@context": [
+                    "https://www.w3.org/ns/credentials/v2",
+                    "https://www.w3.org/ns/credentials/examples/v2",
+                    "https://w3id.org/security/suites/ed25519-2020/v1"
+                ],
+                "type": ["VerifiableCredential", "AlumniCredential"],
+                "issuer": "https://vc.example/issuers/5678",
+                "validFrom": "2023-01-01T00:00:00Z",
+                "credentialSubject": {
+                    "id": "did:example:abcdefgh",
+                    "alumniOf": "The School of Examples"
+                },
+                "proof": {
+                    "type": "Ed25519Signature2020",
+                    "created": "2023-02-24T23:36:38Z",
+                    "verificationMethod": "did:key:z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2#z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2",
+                    "proofPurpose": "assertionMethod",
+                    "proofValue": "z57Mm1vboMtZiCyJ4aReZsv8co4Re64Y8GEjL1ZARzMbXZgkARFLqFs1P345NpPGG2hgCrS4nNdvJhpwnrNyG3kEF"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let (proofs, matched_jwt) = credential
+            .filter_proofs(None, None, &DIDExample)
+            .await
+            .unwrap();
+
+        assert_eq!(proofs.len(), 1);
+        assert!(!matched_jwt);
+    }
 
     #[test]
     fn numeric_date() {


### PR DESCRIPTION
This fixes the SSI-level gaps behind LearnCard's remaining W3C EdDSA Data Integrity failures.

- Reject undefined JSON-LD terms instead of silently dropping data.
- Embed and use the current Data Integrity v2 context, including the typed `cryptosuite` term.
- Verify credentials with URL issuers against the proof's verification method without trying to resolve the issuer as a DID.
- Add dependency-aware `previousProof` verification, including missing references, cycles, and transitive proof chains.

I rebuilt the LearnCard native and WASM DIDKit artifacts and ran the current W3C EdDSA suite against the HTTP bridge: 44 tests pass. The locked native regression suite also passes all 6 tests.

— OMP