### PR TITLE
[LC-2065] Notify LearnCard after SSI main updates

### DIFF
--- a/.github/workflows/notify-learncard.yml
+++ b/.github/workflows/notify-learncard.yml
@@ -1,10 +1,8 @@
 name: Notify LearnCard
 
 on:
-  workflow_run:
-    workflows: ['ci']
+  push:
     branches: [main]
-    types: [completed]
 
 permissions:
   contents: read
@@ -12,7 +10,6 @@ permissions:
 jobs:
   notify:
     name: Trigger LearnCard DIDKit WASM update
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch LearnCard update
@@ -31,6 +28,6 @@ jobs:
           gh api "repos/${TARGET_REPO}/dispatches" \
               -f event_type="${EVENT_TYPE}" \
               -f client_payload[source_repo]="${{ github.repository }}" \
-              -f client_payload[source_sha]="${{ github.event.workflow_run.head_sha }}" \
-              -f client_payload[source_branch]="${{ github.event.workflow_run.head_branch }}" \
-              -f client_payload[workflow_run_id]="${{ github.event.workflow_run.id }}"
+              -f client_payload[source_sha]="${{ github.sha }}" \
+              -f client_payload[source_branch]="${{ github.ref_name }}" \
+              -f client_payload[workflow_run_id]="${{ github.run_id }}"

--- a/.github/workflows/notify-learncard.yml
+++ b/.github/workflows/notify-learncard.yml
@@ -1,0 +1,36 @@
+name: Notify LearnCard
+
+on:
+  workflow_run:
+    workflows: ['ci']
+    branches: [main]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Trigger LearnCard DIDKit WASM update
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch LearnCard update
+        env:
+          EVENT_TYPE: ssi-main-updated
+          GH_TOKEN: ${{ secrets.LEARNCARD_DISPATCH_TOKEN }}
+          TARGET_REPO: learningeconomy/LearnCard
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN}" ]; then
+              echo "::error::Set LEARNCARD_DISPATCH_TOKEN to a token that can dispatch workflows in ${TARGET_REPO}."
+              exit 1
+          fi
+
+          gh api "repos/${TARGET_REPO}/dispatches" \
+              -f event_type="${EVENT_TYPE}" \
+              -f client_payload[source_repo]="${{ github.repository }}" \
+              -f client_payload[source_sha]="${{ github.event.workflow_run.head_sha }}" \
+              -f client_payload[source_branch]="${{ github.event.workflow_run.head_branch }}" \
+              -f client_payload[workflow_run_id]="${{ github.event.workflow_run.id }}"

--- a/.github/workflows/notify-learncard.yml
+++ b/.github/workflows/notify-learncard.yml
@@ -29,5 +29,6 @@ jobs:
               -f event_type="${EVENT_TYPE}" \
               -f client_payload[source_repo]="${{ github.repository }}" \
               -f client_payload[source_sha]="${{ github.sha }}" \
+              -f client_payload[ssi_ref]="${{ github.sha }}" \
               -f client_payload[source_branch]="${{ github.ref_name }}" \
               -f client_payload[workflow_run_id]="${{ github.run_id }}"


### PR DESCRIPTION
## Overview

Every push to `main` sends an `ssi-main-updated` repository dispatch to `learningeconomy/LearnCard`. The event pins `ssi_ref` to the triggering commit, so [LearnCard #1220](https://github.com/learningeconomy/LearnCard/pull/1220) builds the exact update without nightly polling.

## Trigger behavior

This intentionally dispatches directly from `push`, rather than waiting for the legacy `ci` workflow. That workflow is already failing on `main` because of formatting drift and the yanked `core2@0.4.0` dependency. The LearnCard receiver is the WASM-specific gate: it builds the pinned revision, runs plugin tests and a runtime smoke test, and only uploads after those checks pass.

## Required setup

Before merging, add `LEARNCARD_DISPATCH_TOKEN` as a repository Actions secret. The token needs permission to call `POST /repos/learningeconomy/LearnCard/dispatches` (Contents: write for a fine-grained token).

## Validation

- The notification workflow passes `actionlint`.
- Event name, pinned ref, and traceability fields match the receiver in LearnCard #1220.
- Current PR failures reproduce the repository's existing `main` failures and are unrelated to this workflow-only change.

- OMP