### PR TITLE
[LC-1958] Add explicit issuer authorization verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ solana = ["ssi-ldp/solana"]
 ring = ["ssi-jwk/ring", "ssi-jws/ring", "ssi-crypto/ring"]
 
 http-did = ["ssi-dids/http"]
-example-http-issuer = ["ssi-ldp/example-http-issuer"]
 
 # Backward compatibility features
 ed25519-dalek = ["ed25519"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,8 +120,6 @@ pub enum Error {
     UnsupportedMultipleVMs,
     /// Key type not implemented
     KeyTypeNotImplemented,
-    /// Unsupported non-DID issuer
-    UnsupportedNonDIDIssuer(String),
     /// Curve not implemented
     CurveNotImplemented(String),
     /// JWT key not found
@@ -476,7 +474,6 @@ impl fmt::Display for Error {
             Error::UnsupportedAlgorithm => write!(f, "Unsupported algorithm"),
             Error::UnsupportedCurve => write!(f, "Unsupported curve"),
             Error::UnsupportedMultipleVMs => write!(f, "Unsupported multiple verification methods"),
-            Error::UnsupportedNonDIDIssuer(issuer) => write!(f, "Unsupported non-DID issuer: {}", issuer),
             Error::KeyTypeNotImplemented => write!(f, "Key type not implemented"),
             Error::CurveNotImplemented(curve) => write!(f, "Curve not implemented: '{:?}'", curve),
             Error::TimeError => write!(f, "Unable to convert date/time"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 //! `solana`              |         | Enable Solana related signature suites and cryptographic dependencies.
 //! `ring`                |         | Use the [ring](https://crates.io/crates/ring) crate for RSA, Ed25519, and SHA-256 functionality.
 //! `http-did`            |         | Enable DID resolution tests using [hyper](https://crates.io/crates/hyper) and [tokio](https://crates.io/crates/tokio).
-//! `example-http-issuer` |         | Enable resolving example HTTPS Verifiable credential Issuer URL, for [VC Test Suite](https://github.com/w3c/vc-test-suite/).
 #![cfg_attr(docsrs, feature(doc_auto_cfg), feature(doc_cfg))]
 
 // maintain old structure here

--- a/ssi-dids/src/did_resolve.rs
+++ b/ssi-dids/src/did_resolve.rs
@@ -1231,6 +1231,112 @@ impl DIDResolver for HTTPDIDResolver {
     }
 }
 
+/// Resolve controlled identifier documents supplied by the caller.
+///
+/// This is useful when the identifier is not a DID, so a DID method cannot
+/// resolve it, but the caller has already dereferenced the identifier's
+/// document.
+#[derive(Clone, Default)]
+pub struct StaticDocumentResolver {
+    pub documents: HashMap<String, Document>,
+}
+
+impl StaticDocumentResolver {
+    pub fn new(documents: HashMap<String, Document>) -> Self {
+        Self { documents }
+    }
+
+    /// Parse controlled identifier documents from a mixed JSON document map.
+    ///
+    /// JSON-LD context documents and documents whose `id` does not match their
+    /// map key are ignored.
+    pub fn from_json_map(document_map: &HashMap<String, String>) -> Self {
+        let documents = document_map
+            .iter()
+            .filter(|(identifier, _)| {
+                identifier.starts_with("http://") || identifier.starts_with("https://")
+            })
+            .filter_map(|(identifier, json)| {
+                let document = Document::from_json(json).ok()?;
+
+                (document.id.to_string() == *identifier).then(|| (identifier.clone(), document))
+            })
+            .collect();
+
+        Self { documents }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl DIDResolver for StaticDocumentResolver {
+    async fn resolve(
+        &self,
+        identifier: &str,
+        _input_metadata: &ResolutionInputMetadata,
+    ) -> (
+        ResolutionMetadata,
+        Option<Document>,
+        Option<DocumentMetadata>,
+    ) {
+        if let Some(document) = self.documents.get(identifier) {
+            return (
+                ResolutionMetadata::default(),
+                Some(document.clone()),
+                Some(DocumentMetadata::default()),
+            );
+        }
+
+        if (identifier == "https:" || identifier == "http:")
+            && self
+                .documents
+                .keys()
+                .any(|document_id| document_id.starts_with(identifier))
+        {
+            return (
+                ResolutionMetadata::default(),
+                Some(Document::new(identifier)),
+                Some(DocumentMetadata::default()),
+            );
+        }
+
+        let error = if identifier.starts_with("http://") || identifier.starts_with("https://") {
+            ERROR_NOT_FOUND
+        } else {
+            ERROR_METHOD_NOT_SUPPORTED
+        };
+
+        (ResolutionMetadata::from_error(error), None, None)
+    }
+
+    async fn dereference(
+        &self,
+        primary_identifier_url: &PrimaryDIDURL,
+        _input_metadata: &DereferencingInputMetadata,
+    ) -> Option<(DereferencingMetadata, Content, ContentMetadata)> {
+        let identifier = primary_identifier_url.to_string();
+
+        if let Some(document) = self.documents.get(&identifier) {
+            return Some((
+                DereferencingMetadata {
+                    content_type: Some(TYPE_DID_LD_JSON.to_string()),
+                    ..Default::default()
+                },
+                Content::DIDDocument(document.clone()),
+                ContentMetadata::default(),
+            ));
+        }
+
+        (identifier.starts_with("http://") || identifier.starts_with("https://")).then(|| {
+            (
+                DereferencingMetadata::from_error(ERROR_NOT_FOUND),
+                Content::Null,
+                ContentMetadata::default(),
+            )
+        })
+    }
+}
+
 /// Compose multiple DID resolvers in series.
 ///
 /// Each underlying DID resolver is tried in series until one supports the

--- a/ssi-ldp/Cargo.toml
+++ b/ssi-ldp/Cargo.toml
@@ -26,7 +26,6 @@ aleo = ["ssi-jws/aleo", "ssi-caips/aleo"]
 ## enable LDPs from the Solana Ecosystem
 solana = []
 
-example-http-issuer = []
 test = []
 
 [dependencies]

--- a/ssi-ldp/src/error.rs
+++ b/ssi-ldp/src/error.rs
@@ -24,8 +24,6 @@ pub enum Error {
     ExpectedMultibaseZ,
     #[error("A verification method MUST NOT contain multiple verification material properties for the same material.")]
     MultipleKeyMaterial,
-    #[error("Unsupported non-DID issuer: {0}")]
-    UnsupportedNonDIDIssuer(String),
     #[error("Missing proof purpose")]
     MissingProofPurpose,
     #[error("Linked Data Proof type not implemented or not enabled by feature")]

--- a/ssi-ldp/src/lib.rs
+++ b/ssi-ldp/src/lib.rs
@@ -317,23 +317,6 @@ pub async fn ensure_or_pick_verification_relationship(
         .as_ref()
         .ok_or(Error::MissingProofPurpose)?
         .clone();
-    if !issuer.starts_with("did:") {
-        // TODO: support non-DID issuers.
-        // Unable to verify verification relationship for non-DID issuers.
-        // Allow some for testing purposes only.
-        match issuer {
-            #[cfg(feature = "example-http-issuer")]
-            "https://example.edu/issuers/14" | "https://vc.example/issuers/5678" => {
-                // https://github.com/w3c/vc-test-suite/blob/cdc7835/test/vc-data-model-1.0/input/example-016-jwt.jsonld#L8
-                // We don't have a way to actually resolve this to anything. Just allow it for
-                // vc-test-suite for now.
-                return Ok(());
-            }
-            _ => {
-                return Err(Error::UnsupportedNonDIDIssuer(issuer.to_string()));
-            }
-        }
-    }
     if let Some(URI::String(ref vm_id)) = options.verification_method {
         ensure_verification_relationship(issuer, proof_purpose, vm_id, key, resolver).await?;
     } else {

--- a/ssi-ldp/src/proof.rs
+++ b/ssi-ldp/src/proof.rs
@@ -301,6 +301,7 @@ pub enum Check {
     JWS,
     Status,
     Schema,
+    IssuerAuthorization,
 }
 
 impl FromStr for Check {
@@ -311,6 +312,7 @@ impl FromStr for Check {
             "JWS" => Ok(Self::JWS),
             "credentialStatus" => Ok(Self::Status),
             "credentialSchema" => Ok(Self::Schema),
+            "issuerAuthorization" => Ok(Self::IssuerAuthorization),
             _ => Err(Error::UnsupportedCheck),
         }
     }
@@ -330,6 +332,7 @@ impl From<Check> for String {
             Check::JWS => "JWS".to_string(),
             Check::Status => "credentialStatus".to_string(),
             Check::Schema => "credentialSchema".to_string(),
+            Check::IssuerAuthorization => "issuerAuthorization".to_string(),
         }
     }
 }

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -45,7 +45,7 @@ k256 = { version = "0.11", features = ["ecdsa"] }
 keccak-hash = { version = "0.7" }
 serde_jcs = "0.1"
 ssi-crypto = { path = "../ssi-crypto" }
-ssi-ldp = { path = "../ssi-ldp", features = ["aleo", "example-http-issuer", "secp384r1"] }
+ssi-ldp = { path = "../ssi-ldp", features = ["aleo", "secp384r1"] }
 ssi-dids = { path = "../ssi-dids", version = "0.1", features = ["example"] }
 josekit = "0.8.2"
 time = "0.3.20"

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -1180,7 +1180,8 @@ impl Credential {
         }
         // TODO: error if any unconvertable claims
         // TODO: unify with verify function?
-        let warn_unchecked_issuer = vc.has_non_did_issuer();
+        let check_issuer_authorization = checks.contains(&Check::IssuerAuthorization);
+        let warn_unchecked_issuer = vc.has_non_did_issuer() && !check_issuer_authorization;
 
         let (proofs, matched_jwt) = match vc
             .filter_proofs(options_opt, Some((&header, &claims)), resolver)
@@ -1221,26 +1222,37 @@ impl Credential {
                     .errors
                     .push(format!("Unable to verify signature: {}", err)),
             }
-            if results.checks.contains(&Check::JWS) && warn_unchecked_issuer {
-                results.warnings.push(NON_DID_ISSUER_WARNING.to_string());
+            if results.checks.contains(&Check::JWS) {
+                if check_issuer_authorization {
+                    results.checks.push(Check::IssuerAuthorization);
+                } else if warn_unchecked_issuer {
+                    results.warnings.push(NON_DID_ISSUER_WARNING.to_string());
+                }
             }
 
             return (Some(vc), results);
         }
         // No JWS verified: try to verify a proof.
         if proofs.is_empty() {
-            return (
-                None,
-                VerificationResult::error("No applicable JWS or proof"),
-            );
+            let error = if check_issuer_authorization {
+                "No JWS or proof authorized by credential issuer"
+            } else {
+                "No applicable JWS or proof"
+            };
+
+            return (None, VerificationResult::error(error));
         }
         results =
             verify_proof_candidates(&vc, vc.proof.as_ref(), proofs, resolver, context_loader).await;
         if checks.contains(&Check::Status) {
             results.append(&mut vc.check_status(resolver, context_loader).await);
         }
-        if results.checks.contains(&Check::Proof) && warn_unchecked_issuer {
-            results.warnings.push(NON_DID_ISSUER_WARNING.to_string());
+        if results.checks.contains(&Check::Proof) {
+            if check_issuer_authorization {
+                results.checks.push(Check::IssuerAuthorization);
+            } else if warn_unchecked_issuer {
+                results.warnings.push(NON_DID_ISSUER_WARNING.to_string());
+            }
         }
 
         (Some(vc), results)
@@ -1313,37 +1325,42 @@ impl Credential {
         jwt_params: Option<(&Header, &JWTClaims)>,
         resolver: &'a dyn DIDResolver,
     ) -> Result<(Vec<&'a Proof>, bool), String> {
-        // Restrict proofs to the issuer's verification methods only when the
-        // issuer is a DID. URL issuers are valid in the VC data model, but do
-        // not have a DID document from which to derive an allowed VM set.
         let mut options = options.unwrap_or_default();
-        let restrict_allowed_vms = match options.verification_method.take() {
-            Some(vm) => Some(vec![vm.to_string()]),
-            None => {
-                if let Some(issuer) = &self.issuer {
-                    let issuer_id = issuer.get_id();
+        let check_issuer_authorization = options
+            .checks
+            .as_ref()
+            .map(|checks| checks.contains(&Check::IssuerAuthorization))
+            .unwrap_or(false);
+        let requested_vm = options
+            .verification_method
+            .take()
+            .map(|verification_method| verification_method.to_string());
+        let restrict_allowed_vms = if let Some(issuer) = &self.issuer {
+            let issuer_id = issuer.get_id();
+            let resolve_issuer = check_issuer_authorization
+                || (issuer_id.starts_with("did:") && requested_vm.is_none());
 
-                    if issuer_id.starts_with("did:") {
-                        let proof_purpose = options
-                            .proof_purpose
-                            .clone()
-                            .unwrap_or(ProofPurpose::AssertionMethod);
+            if resolve_issuer {
+                let proof_purpose = options
+                    .proof_purpose
+                    .clone()
+                    .unwrap_or(ProofPurpose::AssertionMethod);
+                let mut authorized_vms =
+                    get_verification_methods_for_purpose(&issuer_id, resolver, proof_purpose)
+                        .await?;
 
-                        Some(
-                            get_verification_methods_for_purpose(
-                                &issuer_id,
-                                resolver,
-                                proof_purpose,
-                            )
-                            .await?,
-                        )
-                    } else {
-                        None
-                    }
-                } else {
-                    None
+                if let Some(requested_vm) = requested_vm {
+                    authorized_vms.retain(|authorized_vm| authorized_vm == &requested_vm);
                 }
+
+                Some(authorized_vms)
+            } else {
+                requested_vm.map(|verification_method| vec![verification_method])
             }
+        } else if check_issuer_authorization {
+            return Err("Credential is missing an issuer".to_string());
+        } else {
+            requested_vm.map(|verification_method| vec![verification_method])
         };
         let matched_proofs = self
             .proof
@@ -1378,12 +1395,12 @@ impl Credential {
         resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
     ) -> VerificationResult {
-        let warn_unchecked_issuer = self.has_non_did_issuer();
-
         let checks = options
             .as_ref()
             .and_then(|opts| opts.checks.clone())
             .unwrap_or_default();
+        let check_issuer_authorization = checks.contains(&Check::IssuerAuthorization);
+        let warn_unchecked_issuer = self.has_non_did_issuer() && !check_issuer_authorization;
         let (proofs, _) = match self.filter_proofs(options, None, resolver).await {
             Ok(proofs) => proofs,
             Err(err) => {
@@ -1391,8 +1408,13 @@ impl Credential {
             }
         };
         if proofs.is_empty() {
-            return VerificationResult::error("No applicable proof");
-            // TODO: say why, e.g. expired
+            let error = if check_issuer_authorization {
+                "No proof authorized by credential issuer"
+            } else {
+                "No applicable proof"
+            };
+
+            return VerificationResult::error(error);
         }
         let mut results =
             verify_proof_candidates(self, self.proof.as_ref(), proofs, resolver, context_loader)
@@ -1404,8 +1426,12 @@ impl Credential {
         if checks.contains(&Check::Schema) {
             results.append(&mut self.check_schema(resolver, context_loader).await);
         }
-        if results.checks.contains(&Check::Proof) && warn_unchecked_issuer {
-            results.warnings.push(NON_DID_ISSUER_WARNING.to_string());
+        if results.checks.contains(&Check::Proof) {
+            if check_issuer_authorization {
+                results.checks.push(Check::IssuerAuthorization);
+            } else if warn_unchecked_issuer {
+                results.warnings.push(NON_DID_ISSUER_WARNING.to_string());
+            }
         }
 
         results

--- a/ssi-vc/tests/di.rs
+++ b/ssi-vc/tests/di.rs
@@ -6,13 +6,14 @@ use serde::Deserialize;
 use ssi_dids::{
     did_resolve::{
         Content, ContentMetadata, DIDResolver, DereferencingInputMetadata, DereferencingMetadata,
-        DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, TYPE_DID_LD_JSON,
+        DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, StaticDocumentResolver,
+        TYPE_DID_LD_JSON,
     },
     Document, PrimaryDIDURL,
 };
 use ssi_json_ld::ContextLoader;
 use ssi_jwk::JWK;
-use ssi_ldp::{dataintegrity::DataIntegrityCryptoSuite, ProofSuiteType};
+use ssi_ldp::{dataintegrity::DataIntegrityCryptoSuite, Check, ProofSuiteType};
 use ssi_vc::{Credential, LinkedDataProofOptions, OneOrMany, ProofPurpose, URI};
 
 #[derive(Deserialize)]
@@ -151,6 +152,10 @@ async fn vc_di_eddsa_ed25519signature2020() {
 
     let unsigned_vc = include_str!("../../tests/vc-di-eddsa/TestVectors/unsigned.json");
     let mut unsigned_vc: Credential = serde_json::from_str(unsigned_vc).unwrap();
+    let resolver = StaticDocumentResolver::new(HashMap::from([(
+        DI_ISSUER.to_string(),
+        Document::from_json(DI_ISSUER_JSON).unwrap(),
+    )]));
     let key: KeyPair = serde_json::from_str(include_str!(
         "../../tests/vc-di-eddsa/TestVectors/keyPair.json"
     ))
@@ -165,7 +170,7 @@ async fn vc_di_eddsa_ed25519signature2020() {
                 verification_method: Some(URI::String("https://vc.example/issuers/5678#z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2".into())),
                 ..Default::default()
             },
-            &DiResolver,
+            &resolver,
             &mut ContextLoader::default(),
         )
         .await
@@ -173,9 +178,31 @@ async fn vc_di_eddsa_ed25519signature2020() {
     assert!(proof.proof_value.is_some());
     unsigned_vc.proof = Some(OneOrMany::One(proof));
     let res = unsigned_vc
-        .verify(None, &DiResolver, &mut ContextLoader::default())
+        .verify(None, &resolver, &mut ContextLoader::default())
         .await;
     assert_eq!(res.errors, Vec::<String>::default());
+    assert_eq!(
+        res.warnings,
+        vec![
+            "Issuer authorization was not checked because the credential issuer is not a DID"
+                .to_string()
+        ]
+    );
+
+    let res = unsigned_vc
+        .verify(
+            Some(LinkedDataProofOptions {
+                checks: Some(vec![Check::Proof, Check::IssuerAuthorization]),
+                ..Default::default()
+            }),
+            &resolver,
+            &mut ContextLoader::default(),
+        )
+        .await;
+    assert_eq!(res.errors, Vec::<String>::default());
+    assert!(res.checks.contains(&Check::Proof));
+    assert!(res.checks.contains(&Check::IssuerAuthorization));
+    assert!(res.warnings.is_empty());
 }
 
 struct TestParams {

--- a/vc-test/Cargo.toml
+++ b/vc-test/Cargo.toml
@@ -8,7 +8,7 @@ description = "vc-test-suite test driver for ssi"
 publish = false
 
 [dependencies]
-ssi = { path = "../", features = ["example-http-issuer"] }
+ssi = { path = "../" }
 ssi-ldp = { path = "../ssi-ldp", default-features = false, features = ["test"] }
 ssi-dids = { path = "../ssi-dids", features = ["example"] }
 async-std = { version = "1.9", features = ["attributes"] }


### PR DESCRIPTION
## What

Adds an explicit `issuerAuthorization` verification check for credentials whose issuer is an HTTP(S) URL. A normal `proof` check still verifies signature integrity and returns the existing warning; requesting `issuerAuthorization` now resolves the issuer's controlled identifier document, checks the proof-purpose relationship, and fails closed when the key is not authorized.

Also adds a caller-supplied `StaticDocumentResolver` that handles HTTP(S) identifiers and fragment dereferencing, removes the old hard-coded test-issuer bypass, and covers the URL-key path with the Ed25519 fixture.

## Verification

- `cargo test -p ssi-vc --test di vc_di_eddsa_ed25519signature2020`
- `cargo test -p ssi-ldp --lib`
- LearnCard native and checked-in WASM bridge smoke tests pass for authorized, warning-only, and unauthorized URL issuers.

## Stack

Targets `fix/eddsa-data-integrity-review` so this stays separate from, but builds on, the current LC-1958 SSI review branch.