### PR TITLE
fix: bump pgp to 0.14 in did-webkey (4 high Dependabot alerts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -74,15 +74,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.12"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2 0.10.6",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
  "zeroize",
 ]
@@ -657,7 +657,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35b8a1c0fea99bf5301d3851e261168de966419c1d02a705a7ca11da64e54827"
 dependencies = [
- "ahash 0.8.12",
+ "ahash 0.8.11",
  "base64 0.21.7",
  "fluent-uri",
  "idna 0.5.0",
@@ -739,13 +739,13 @@ checksum = "92680fcbb8e24eaa4640c6deca0042db02da17c8b92fde62a0c517bcb6769d7d"
 dependencies = [
  "async-trait",
  "hex",
- "http",
+ "http 0.2.12",
  "iri-string",
  "libipld",
  "serde",
  "serde_with 2.3.3",
  "siwe",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "url",
 ]
@@ -769,7 +769,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "instant",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -815,6 +815,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -897,12 +914,6 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
-
-[[package]]
-name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
@@ -966,6 +977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc24"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,16 +1039,6 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
-dependencies = [
- "generic-array 0.14.9",
- "subtle 2.6.1",
-]
 
 [[package]]
 name = "crypto-bigint"
@@ -1144,7 +1154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto 0.2.9",
@@ -1292,7 +1302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.106",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1331,22 +1341,11 @@ checksum = "5440d1dc8ea7cae44cda3c64568db29bfa2434aba51ae66a50c00488841a65a3"
 
 [[package]]
 name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid 0.7.1",
- "crypto-bigint 0.3.2",
- "pem-rfc7468 0.3.1",
-]
-
-[[package]]
-name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468 0.6.0",
  "zeroize",
 ]
@@ -1357,7 +1356,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468 0.7.0",
  "zeroize",
 ]
@@ -1508,7 +1507,7 @@ dependencies = [
  "ssi-jwk",
  "ssi-jws",
  "ssi-jwt",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1546,7 +1545,7 @@ dependencies = [
  "ssi-jwk",
  "ssi-ldp",
  "ssi-vc",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1556,8 +1555,8 @@ dependencies = [
  "async-std",
  "async-trait",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.32",
  "reqwest",
  "serde",
  "serde_json",
@@ -1644,8 +1643,8 @@ dependencies = [
  "async-trait",
  "cached 0.44.0",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.32",
  "lazy_static",
  "reqwest",
  "serde",
@@ -1668,8 +1667,8 @@ dependencies = [
  "env_logger 0.10.2",
  "futures",
  "hex",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.32",
  "pgp",
  "pretty_assertions",
  "reqwest",
@@ -1720,7 +1719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
+ "const-oid",
  "crypto-common",
  "subtle 2.6.1",
 ]
@@ -2346,8 +2345,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2423,7 +2436,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.11.4",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.5.0",
  "indexmap 2.11.4",
  "slab",
  "tokio",
@@ -2455,7 +2487,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -2526,13 +2558,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http 1.5.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -2546,7 +2611,7 @@ dependencies = [
  "async-channel 1.9.0",
  "base64 0.13.1",
  "futures-lite 1.13.0",
- "http",
+ "http 0.2.12",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -2585,9 +2650,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2600,30 +2665,81 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.24.2"
+name = "hyper"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
- "futures-util",
- "http",
- "hyper",
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2 0.4.19",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.5.0",
+ "hyper 1.11.1",
+ "hyper-util",
  "rustls",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.11.1",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "hyper 1.11.1",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.1",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2910,7 +3026,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -2940,7 +3056,7 @@ dependencies = [
  "json-syntax",
  "locspan",
  "rdf-types",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2962,7 +3078,7 @@ dependencies = [
  "locspan",
  "mown",
  "rdf-types",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2979,7 +3095,7 @@ dependencies = [
  "locspan",
  "mown",
  "rdf-types",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3008,7 +3124,7 @@ dependencies = [
  "ryu-js",
  "smallvec",
  "static-iref",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3029,7 +3145,7 @@ dependencies = [
  "locspan",
  "mown",
  "rdf-types",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3050,7 +3166,7 @@ dependencies = [
  "locspan-derive",
  "rdf-types",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3128,7 +3244,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3254,7 +3370,7 @@ dependencies = [
  "log",
  "multihash",
  "parking_lot",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3265,7 +3381,7 @@ checksum = "8dd1ab68c9d26f20c7d0dfea6eecbae8c00359875210001b33ca27d4a02f3d09"
 dependencies = [
  "byteorder",
  "libipld-core",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3293,7 +3409,7 @@ dependencies = [
  "multibase 0.9.2",
  "multihash",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3386,6 +3502,12 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "value-bag",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "match-lookup"
@@ -3590,11 +3712,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -3614,13 +3735,13 @@ checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3909,15 +4030,6 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "pem-rfc7468"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
@@ -3968,7 +4080,7 @@ dependencies = [
  "cfb-mode",
  "chrono",
  "cipher",
- "const-oid 0.9.6",
+ "const-oid",
  "crc24",
  "curve25519-dalek 4.1.3",
  "derive_builder 0.20.2",
@@ -3999,14 +4111,14 @@ dependencies = [
  "p521",
  "rand 0.8.5",
  "ripemd",
- "rsa 0.9.8",
+ "rsa",
  "sha1",
  "sha1-checked",
  "sha2 0.10.9",
  "sha3",
  "signature 2.2.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "twofish",
  "x25519-dalek",
  "x448",
@@ -4038,17 +4150,6 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
-dependencies = [
- "der 0.5.1",
- "pkcs8 0.8.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
@@ -4056,17 +4157,6 @@ dependencies = [
  "der 0.7.10",
  "pkcs8 0.10.2",
  "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
-dependencies = [
- "der 0.5.1",
- "spki 0.5.4",
- "zeroize",
 ]
 
 [[package]]
@@ -4116,7 +4206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug 0.3.1",
  "universal-hash",
 ]
@@ -4142,7 +4232,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.27",
 ]
 
 [[package]]
@@ -4198,7 +4288,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
  "toml",
 ]
 
@@ -4236,6 +4326,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.1",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring 0.17.14",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4249,6 +4395,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -4297,6 +4449,17 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4353,12 +4516,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4461,47 +4639,46 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.4.19",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.11.1",
  "hyper-rustls",
  "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tokio-socks",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
 ]
 
 [[package]]
@@ -4582,36 +4759,16 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.6.1"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "byteorder",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-iter",
- "num-traits",
- "pkcs1 0.3.3",
- "pkcs8 0.8.0",
- "rand_core 0.6.4",
- "smallvec",
- "subtle 2.6.1",
- "zeroize",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
-dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1 0.7.5",
+ "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "signature 2.2.0",
@@ -4653,6 +4810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4676,32 +4839,36 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "log",
+ "once_cell",
  "ring 0.17.14",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle 2.6.1",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls-pki-types"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
- "base64 0.21.7",
+ "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring 0.17.14",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -4743,16 +4910,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "sec1"
@@ -4893,7 +5050,7 @@ checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4966,7 +5123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -5001,7 +5158,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug 0.3.1",
 ]
@@ -5013,7 +5170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -5077,7 +5234,7 @@ dependencies = [
  "chrono",
  "num-bigint 0.4.6",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5087,12 +5244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6d1f422a568af1e98db37c6d0427c7218459ccac39218fd15a51a34d3933af"
 dependencies = [
  "hex",
- "http",
+ "http 0.2.12",
  "iri-string",
  "k256 0.11.6",
  "rand 0.8.5",
  "sha3",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -5107,7 +5264,7 @@ dependencies = [
  "serde",
  "serde_json",
  "siwe",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5156,7 +5313,7 @@ dependencies = [
  "snarkvm-profiler",
  "snarkvm-r1cs",
  "snarkvm-utilities",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5172,7 +5329,7 @@ dependencies = [
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5217,7 +5374,7 @@ dependencies = [
  "snarkvm-profiler",
  "snarkvm-r1cs",
  "snarkvm-utilities",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5233,7 +5390,7 @@ dependencies = [
  "rand_xorshift 0.3.0",
  "serde",
  "snarkvm-utilities",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5253,7 +5410,7 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-r1cs",
  "snarkvm-utilities",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5290,7 +5447,7 @@ dependencies = [
  "hex",
  "snarkvm-algorithms",
  "snarkvm-utilities",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5344,7 +5501,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "rand 0.8.5",
  "snarkvm-derives",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5378,16 +5535,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
-dependencies = [
- "base64ct",
- "der 0.5.1",
-]
 
 [[package]]
 name = "spki"
@@ -5452,7 +5599,7 @@ dependencies = [
  "bs58 0.4.0",
  "serde_json",
  "ssi-jwk",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5465,7 +5612,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5488,7 +5635,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sha2 0.8.2",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -5521,7 +5668,7 @@ dependencies = [
  "derive_builder 0.9.0",
  "futures",
  "hex",
- "hyper",
+ "hyper 0.14.32",
  "iref",
  "multibase 0.8.0",
  "percent-encoding",
@@ -5534,7 +5681,7 @@ dependencies = [
  "ssi-json-ld",
  "ssi-jwk",
  "static-iref",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -5558,7 +5705,7 @@ dependencies = [
  "ssi-contexts",
  "ssi-crypto",
  "static-iref",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -5584,7 +5731,7 @@ dependencies = [
  "rand 0.7.3",
  "rand 0.8.5",
  "ring 0.16.20",
- "rsa 0.6.1",
+ "rsa",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -5594,7 +5741,7 @@ dependencies = [
  "snarkvm-parameters",
  "snarkvm-utilities",
  "ssi-crypto",
- "thiserror",
+ "thiserror 1.0.69",
  "unsigned-varint",
  "zeroize",
 ]
@@ -5612,13 +5759,13 @@ dependencies = [
  "p384 0.11.2",
  "rand 0.8.5",
  "ring 0.16.20",
- "rsa 0.6.1",
+ "rsa",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "ssi-crypto",
  "ssi-jwk",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5631,7 +5778,7 @@ dependencies = [
  "serde_with 2.3.3",
  "ssi-jwk",
  "ssi-jws",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5667,7 +5814,7 @@ dependencies = [
  "ssi-jws",
  "ssi-tzkey",
  "static-iref",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5676,7 +5823,7 @@ version = "0.1.0"
 dependencies = [
  "sshkeys",
  "ssi-jwk",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5689,7 +5836,7 @@ dependencies = [
  "serde_json",
  "ssi-jwk",
  "ssi-jws",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5710,7 +5857,7 @@ dependencies = [
  "ssi-jwk",
  "ssi-jws",
  "ssi-jwt",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5747,7 +5894,7 @@ dependencies = [
  "ssi-jws",
  "ssi-jwt",
  "ssi-ldp",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -5777,7 +5924,7 @@ dependencies = [
  "ssi-json-ld",
  "ssi-jwk",
  "ssi-ldp",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5854,10 +6001,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.2"
+name = "syn"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -5884,20 +6045,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.4",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5969,7 +6130,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -5981,6 +6151,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6095,23 +6276,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-socks"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
-dependencies = [
- "either",
- "futures-util",
- "thiserror",
  "tokio",
 ]
 
@@ -6136,6 +6305,45 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytes",
+ "futures-util",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -6471,10 +6679,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -6549,6 +6770,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6564,15 +6796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6600,21 +6823,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6652,12 +6860,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6670,12 +6872,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6685,12 +6881,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6718,12 +6908,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6733,12 +6917,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6754,12 +6932,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6769,12 +6941,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6789,16 +6955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wiremock"
 version = "0.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6811,7 +6967,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "http-types",
- "hyper",
+ "hyper 0.14.32",
  "log",
  "once_cell",
  "regex",
@@ -6893,11 +7049,31 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.27",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array 0.14.9",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +36,29 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle 2.6.1",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
 ]
 
 [[package]]
@@ -125,6 +158,19 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2 0.10.6",
+ "cpufeatures",
+ "password-hash",
+ "zeroize",
+]
 
 [[package]]
 name = "arrayref"
@@ -818,6 +864,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.9",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1025,6 +1083,15 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.9",
  "subtle 2.6.1",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1080,7 +1147,7 @@ dependencies = [
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "subtle 2.6.1",
  "zeroize",
@@ -1119,16 +1186,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -1156,20 +1213,6 @@ name = "darling_core"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1217,17 +1260,6 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
@@ -1261,6 +1293,15 @@ checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array 0.14.9",
 ]
 
 [[package]]
@@ -1357,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.12.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
  "derive_builder_macro",
 ]
@@ -1378,24 +1419,45 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_core"
-version = "0.12.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling 0.14.4",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.12.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
- "derive_builder_core 0.12.0",
- "syn 1.0.109",
+ "derive_builder_core 0.20.2",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1472,7 +1534,7 @@ dependencies = [
  "async-trait",
  "bs58 0.5.1",
  "curve25519-dalek 4.1.3",
- "k256",
+ "k256 0.11.6",
  "multibase 0.8.0",
  "p256 0.11.1",
  "serde",
@@ -1675,6 +1737,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8 0.10.2",
+ "rfc6979 0.4.0",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "zeroize",
+]
+
+[[package]]
+name = "eax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
+dependencies = [
+ "aead",
+ "cipher",
+ "cmac",
+ "ctr",
+ "subtle 2.6.1",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +1836,17 @@ dependencies = [
  "sha2 0.10.9",
  "subtle 2.6.1",
  "zeroize",
+]
+
+[[package]]
+name = "ed448-goldilocks"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b5fa9e9e3dd5fe1369f380acd3dcdfa766dbd0a1cd5b048fb40e38a6a78e79"
+dependencies = [
+ "fiat-crypto 0.1.20",
+ "hex",
+ "subtle 2.6.1",
 ]
 
 [[package]]
@@ -1971,6 +2073,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fiat-crypto"
@@ -2240,6 +2348,16 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug 0.3.1",
+ "polyval",
 ]
 
 [[package]]
@@ -2758,6 +2876,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "iter-read"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071ed4cc1afd86650602c7b11aa2e1ce30762a1c27193201cb5cee9c6ebb1294"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3106,20 @@ dependencies = [
  "elliptic-curve 0.12.3",
  "sha2 0.10.9",
  "sha3",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "once_cell",
+ "sha2 0.10.9",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3486,17 +3624,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,12 +3664,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 1.1.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle 2.6.1",
 ]
 
 [[package]]
@@ -3669,6 +3830,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct 0.2.0",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pairing-plus"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3710,6 +3885,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle 2.6.1",
 ]
 
 [[package]]
@@ -3762,12 +3948,15 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pgp"
-version = "0.10.2"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e1f8e085bfa9b85763fe3ddaacbe90a09cd847b3833129153a6cb063bbe132"
+checksum = "1877a97fd422433220ad272eb008ec55691944b1200e9eb204e3cb2cb69d34e9"
 dependencies = [
  "aes",
- "base64 0.21.7",
+ "aes-gcm",
+ "aes-kw",
+ "argon2",
+ "base64 0.22.1",
  "bitfield",
  "block-padding 0.3.3",
  "blowfish",
@@ -3779,29 +3968,40 @@ dependencies = [
  "cfb-mode",
  "chrono",
  "cipher",
+ "const-oid 0.9.6",
  "crc24",
  "curve25519-dalek 4.1.3",
- "derive_builder 0.12.0",
+ "derive_builder 0.20.2",
+ "derive_more",
  "des",
  "digest 0.10.7",
+ "dsa",
+ "eax",
+ "ecdsa 0.16.9",
  "ed25519-dalek 2.2.0",
  "elliptic-curve 0.13.8",
  "flate2",
  "generic-array 0.14.9",
  "hex",
+ "hkdf 0.12.4",
  "idea",
+ "iter-read",
+ "k256 0.13.4",
  "log",
  "md-5",
  "nom",
  "num-bigint-dig",
- "num-derive 0.4.2",
  "num-traits",
+ "num_enum",
+ "ocb3",
  "p256 0.13.2",
  "p384 0.13.1",
+ "p521",
  "rand 0.8.5",
  "ripemd",
  "rsa 0.9.8",
  "sha1",
+ "sha1-checked",
  "sha2 0.10.9",
  "sha3",
  "signature 2.2.0",
@@ -3809,6 +4009,7 @@ dependencies = [
  "thiserror",
  "twofish",
  "x25519-dalek",
+ "x448",
  "zeroize",
 ]
 
@@ -3906,6 +4107,18 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug 0.3.1",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4758,6 +4971,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+ "zeroize",
+]
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4865,7 +5089,7 @@ dependencies = [
  "hex",
  "http",
  "iri-string",
- "k256",
+ "k256 0.11.6",
  "rand 0.8.5",
  "sha3",
  "thiserror",
@@ -5254,7 +5478,7 @@ dependencies = [
  "ed25519-dalek 1.0.1",
  "hex",
  "hkdf 0.8.0",
- "k256",
+ "k256 0.11.6",
  "keccak-hash",
  "p256 0.11.1",
  "pairing-plus",
@@ -5349,11 +5573,11 @@ dependencies = [
  "ed25519-dalek 1.0.1",
  "getrandom 0.2.16",
  "hex",
- "k256",
+ "k256 0.11.6",
  "lazy_static",
  "multibase 0.9.2",
  "num-bigint 0.4.6",
- "num-derive 0.3.3",
+ "num-derive",
  "num-traits",
  "p256 0.11.1",
  "p384 0.11.2",
@@ -5383,7 +5607,7 @@ dependencies = [
  "blake2 0.10.6",
  "clear_on_drop",
  "ed25519-dalek 1.0.1",
- "k256",
+ "k256 0.11.6",
  "p256 0.11.1",
  "p384 0.11.2",
  "rand 0.8.5",
@@ -5422,7 +5646,7 @@ dependencies = [
  "hex",
  "iref",
  "json-syntax",
- "k256",
+ "k256 0.11.6",
  "keccak-hash",
  "lazy_static",
  "locspan",
@@ -5504,7 +5728,7 @@ dependencies = [
  "hex",
  "iref",
  "josekit",
- "k256",
+ "k256 0.11.6",
  "keccak-hash",
  "libipld",
  "multibase 0.8.0",
@@ -6035,6 +6259,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle 2.6.1",
+]
 
 [[package]]
 name = "unsigned-varint"
@@ -6614,6 +6848,17 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x448"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cd07d4fae29e07089dbcacf7077cd52dce7760125ca9a4dd5a35ca603ffebb"
+dependencies = [
+ "ed448-goldilocks",
+ "hex",
+ "rand_core 0.5.1",
 ]
 
 [[package]]

--- a/did-ion/Cargo.toml
+++ b/did-ion/Cargo.toml
@@ -33,10 +33,10 @@ thiserror = "1.0"
 base64 = "0.12"
 sha2 = "0.10"
 json-patch = "0.2.6"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
+version = "0.12"
 features = ["json", "native-tls-vendored"]
 
 [dev-dependencies]

--- a/did-ion/src/sidetree.rs
+++ b/did-ion/src/sidetree.rs
@@ -752,7 +752,6 @@ impl SidetreeOperation for UpdateOperation {
     /// The [DID Suffix](UpdateOperation::did_suffix) is **not** verified
     /// by this function. The correspondence of the reveal value's hash to the previous update
     /// commitment is not checked either, since that is not known from this function.
-
     fn partial_verify<S: Sidetree>(self) -> AResult<PartiallyVerifiedUpdateOperation> {
         // Verify JWS against public key in payload.
         // Then check public key against its hash (reveal value).

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -367,10 +367,7 @@ impl DIDMethod for DIDKey {
                 }
             }
             Params::EC(ref params) => {
-                let curve = match params.curve {
-                    Some(ref curve) => curve,
-                    None => return None,
-                };
+                let curve = params.curve.as_ref()?;
                 match &curve[..] {
                     #[cfg(feature = "secp256k1")]
                     "secp256k1" => {

--- a/did-onion/Cargo.toml
+++ b/did-onion/Cargo.toml
@@ -14,12 +14,12 @@ documentation = "https://docs.rs/did-onion/"
 ssi-dids = { path = "../ssi-dids", version = "0.1", default-features = false }
 ssi-jwk = { path = "../ssi-jwk", version = "0.1" }
 async-trait = "0.1"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "socks"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "socks"] }
 http = "0.2"
 serde_json = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
+version = "0.12"
 features = ["json", "native-tls-vendored"]
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ tokio = { version = "1.0", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"] }
 async-std = { version = "1.9", features = ["attributes"] }
 futures = "0.3"
-hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }
+hyper = { version = "0.14", features = ["server", "client", "http1", "stream", "tcp"] }
 #TODO: socks5-async = "0.1.4"

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -310,19 +310,14 @@ async fn resolve_solana(did: &str, account_address: String, reference: &str) -> 
 
 async fn resolve_bip122(did: &str, account_address: String, reference: &str) -> ResolutionResult {
     match reference {
-        REFERENCE_BIP122_BITCOIN_MAINNET => {
-            if !account_address.starts_with('1') {
-                return resolution_error(ERROR_INVALID_DID);
-            }
+        REFERENCE_BIP122_BITCOIN_MAINNET if !account_address.starts_with('1') => {
+            return resolution_error(ERROR_INVALID_DID);
         }
-        REFERENCE_BIP122_DOGECOIN_MAINNET => {
-            if !account_address.starts_with('D') {
-                return resolution_error(ERROR_INVALID_DID);
-            }
+        REFERENCE_BIP122_DOGECOIN_MAINNET if !account_address.starts_with('D') => {
+            return resolution_error(ERROR_INVALID_DID);
         }
-        _ => {
-            // Unknown network address: no prefix hash check
-        }
+        // Valid known-network prefix, or unknown network with no prefix check.
+        _ => {}
     }
     let blockchain_account_id = BlockchainAccountId {
         account_address,

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -18,7 +18,7 @@ ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, feat
 ssi-jws = { path = "../ssi-jws", version = "0.1", default-features = false }
 ssi-core = { path = "../ssi-core", version = "0.1" }
 chrono = { version = "0.4" }
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
@@ -28,7 +28,7 @@ bs58 = { version = "0.4", features = ["check"] }
 url = "2.2.1"
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
+version = "0.12"
 features = ["json", "native-tls-vendored"]
 
 [dev-dependencies]

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -52,15 +52,14 @@ impl FromStr for Prefix {
     }
 }
 
-impl ToString for Prefix {
-    fn to_string(&self) -> String {
-        match self {
+impl std::fmt::Display for Prefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
             Prefix::TZ1 => "tz1",
             Prefix::TZ2 => "tz2",
             Prefix::TZ3 => "tz3",
             Prefix::KT1 => "KT1",
-        }
-        .to_string()
+        })
     }
 }
 
@@ -532,7 +531,7 @@ impl DIDTz {
                                 })?
                             }
                             #[allow(unreachable_patterns)]
-                            p => return Err(anyhow!("{} support not enabled.", p.to_string())),
+                            p => return Err(anyhow!("{} support not enabled.", p)),
                         };
                         let (_, patch_) = decode_verify(&jws, &jwk)?;
                         patch(

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -317,10 +317,8 @@ fn get_public_key_from_doc(doc: &Document, auth_vm_id: &str) -> Option<String> {
         for vm in vms {
             #[allow(clippy::single_match)]
             match vm {
-                VerificationMethod::Map(vmm) => {
-                    if vmm.id == auth_vm_id {
-                        return vmm.public_key_base58.clone();
-                    }
+                VerificationMethod::Map(vmm) if vmm.id == auth_vm_id => {
+                    return vmm.public_key_base58.clone();
                 }
                 // TODO, derefencing
                 _ => {}

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/did-web/"
 [dependencies]
 ssi-dids = { path = "../ssi-dids", version = "0.1" }
 async-trait = "0.1"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 http = "0.2"
 serde_json = "1.0"
 lazy_static = "1.4"
@@ -22,7 +22,7 @@ cached = { version = "0.44", default-features = false, features = ["wasm"] }
 async-std = "1.12"
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
+version = "0.12"
 features = ["json", "native-tls-vendored"]
 
 [dev-dependencies]
@@ -34,4 +34,4 @@ tokio = { version = "1.0", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"] }
 async-std = { version = "1.9", features = ["attributes"] }
 futures = "0.3"
-hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }
+hyper = { version = "0.14", features = ["server", "client", "http1", "stream", "tcp"] }

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -19,8 +19,10 @@ thread_local! {
   static PROXY: RefCell<Option<String>> = RefCell::new(None);
 }
 
+type CachedResolution = (ResolutionMetadata, Vec<u8>, Option<DocumentMetadata>);
+
 lazy_static::lazy_static! {
-    static ref CACHE: Mutex<TimedCache<String, (ResolutionMetadata, Vec<u8>, Option<DocumentMetadata>)>> = Mutex::new(TimedCache::with_lifespan(10));
+    static ref CACHE: Mutex<TimedCache<String, CachedResolution>> = Mutex::new(TimedCache::with_lifespan(10));
 }
 
 /// did:web Method

--- a/did-webkey/Cargo.toml
+++ b/did-webkey/Cargo.toml
@@ -27,7 +27,7 @@ http = "0.2.6"
 serde_json = "1.0.75"
 serde = { version = "1.0.134", features = ["derive"] }
 sshkeys = "0.3.1"
-pgp = "0.10.0"
+pgp = "0.14"
 
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]

--- a/did-webkey/Cargo.toml
+++ b/did-webkey/Cargo.toml
@@ -21,7 +21,7 @@ ssi-jwk = { version = "0.1", path = "../ssi-jwk" , default-features = false }
 ssi-ssh = { version = "0.1", path = "../ssi-ssh" }
 anyhow = "1.0.52"
 async-trait = "0.1.52"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 hex = "0.4.3"
 http = "0.2.6"
 serde_json = "1.0.75"
@@ -31,7 +31,7 @@ pgp = "0.14"
 
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11.9"
+version = "0.12"
 features = ["json", "native-tls-vendored"]
 
 [dev-dependencies]
@@ -46,4 +46,5 @@ hyper = { version = "0.14.16", features = [
     "client",
     "http1",
     "stream",
+    "tcp",
 ] }

--- a/did-webkey/src/lib.rs
+++ b/did-webkey/src/lib.rs
@@ -87,12 +87,15 @@ fn gpg_pk_to_vm(did: &str, pk: SignedPublicKey) -> Result<(VerificationMethodMap
         }
         res
     };
-    if let Some(user) = pk.details.users.get(0) {
+    if let Some(user) = pk.details.users.first() {
         // Workaround to have the same key multiple times (`Comment`)
         header = format!("{}\nComment: {}", header, user.id.id());
     }
     let headers = BTreeMap::from([("Comment".to_string(), vec![header])]);
-    let armored_pgp = pk.to_armored_string(ArmorOptions { headers: Some(&headers), ..Default::default() })?;
+    let armored_pgp = pk.to_armored_string(ArmorOptions {
+        headers: Some(&headers),
+        ..Default::default()
+    })?;
 
     let vm_map = VerificationMethodMap {
         id: vm_url.to_string(),

--- a/did-webkey/src/lib.rs
+++ b/did-webkey/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use core::str::FromStr;
-use pgp::{types::KeyTrait, Deserializable, SignedPublicKey};
+use pgp::{composed::ArmorOptions, types::PublicKeyTrait, Deserializable, SignedPublicKey};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, io::Cursor};
 
@@ -62,6 +62,7 @@ fn parse_pubkeys_gpg(
 fn gpg_pk_to_vm(did: &str, pk: SignedPublicKey) -> Result<(VerificationMethodMap, DIDURL)> {
     let fingerprint = pk
         .fingerprint()
+        .as_bytes()
         .iter()
         .fold(String::new(), |acc, &x| format!("{}{:02X}", acc, x));
     let vm_url = DIDURL {
@@ -90,8 +91,8 @@ fn gpg_pk_to_vm(did: &str, pk: SignedPublicKey) -> Result<(VerificationMethodMap
         // Workaround to have the same key multiple times (`Comment`)
         header = format!("{}\nComment: {}", header, user.id.id());
     }
-    let headers = BTreeMap::from([("Comment".to_string(), header)]);
-    let armored_pgp = pk.to_armored_string(Some(&headers))?;
+    let headers = BTreeMap::from([("Comment".to_string(), vec![header])]);
+    let armored_pgp = pk.to_armored_string(ArmorOptions { headers: Some(&headers), ..Default::default() })?;
 
     let vm_map = VerificationMethodMap {
         id: vm_url.to_string(),

--- a/ssi-dids/Cargo.toml
+++ b/ssi-dids/Cargo.toml
@@ -23,7 +23,7 @@ derive_builder = "0.9"
 bs58 = { version = "0.4", features = ["check"] }
 hex = "0.4"
 multibase = "0.8"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 percent-encoding = { version = "2.1", optional = true }
 iref = { version = "2.2.2", features = ["serde"] }
 static-iref = "2.0.0"
@@ -48,6 +48,7 @@ hyper = { version = "0.14", features = [
     "client",
     "http1",
     "stream",
+    "tcp",
 ] }
 ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, features = ["secp256k1", "ed25519"] }
 

--- a/ssi-dids/src/did_resolve.rs
+++ b/ssi-dids/src/did_resolve.rs
@@ -130,7 +130,7 @@ pub struct ResolutionMetadata {
 /// - in [DID Core](https://www.w3.org/TR/did-core/#dfn-diddocumentmetadata)
 /// - in [DID Resolution](https://w3c-ccg.github.io/did-resolution/#output-documentmetadata)
 /// - in [DID Specification
-/// Registries](https://www.w3.org/TR/did-spec-registries/#did-document-metadata)
+///   Registries](https://www.w3.org/TR/did-spec-registries/#did-document-metadata)
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentMetadata {
@@ -209,9 +209,12 @@ pub enum Content {
 }
 
 #[cfg(feature = "http")]
-fn get_first_context_uri(value: &Value) -> Option<iref::IriRef> {
+fn get_first_context_uri(value: &Value) -> Option<iref::IriRef<'_>> {
     match value.get("@context")? {
-        Value::Array(vec) => vec.get(0)?.as_str().and_then(|v| iref::IriRef::new(v).ok()),
+        Value::Array(vec) => vec
+            .first()?
+            .as_str()
+            .and_then(|v| iref::IriRef::new(v).ok()),
         Value::String(string) => iref::IriRef::new(string).ok(),
         _ => None,
     }
@@ -1238,7 +1241,7 @@ impl DIDResolver for HTTPDIDResolver {
 #[derive(Clone, Default)]
 pub struct SeriesResolver<'a> {
     /// Underlying DID resolvers.
-    pub resolvers: Vec<&'a (dyn DIDResolver)>,
+    pub resolvers: Vec<&'a dyn DIDResolver>,
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -1621,9 +1624,10 @@ mod tests {
                 if id == DID_KEY_ID {
                     let body = Body::from(DID_KEY_JSON);
                     let mut response = Response::new(body);
-                    response
-                        .headers_mut()
-                        .insert(header::CONTENT_TYPE, TYPE_DID_RESOLUTION.parse().unwrap());
+                    response.headers_mut().insert(
+                        hyper::header::CONTENT_TYPE,
+                        TYPE_DID_RESOLUTION.parse().unwrap(),
+                    );
                     return Ok::<_, hyper::Error>(response);
                 }
 
@@ -1633,11 +1637,12 @@ mod tests {
                     resolver.resolve(&id, &res_input_meta).await;
                 let (mut parts, _) = Response::<Body>::default().into_parts();
                 if res_meta.error == Some(ERROR_NOT_FOUND.to_string()) {
-                    parts.status = StatusCode::NOT_FOUND;
+                    parts.status = hyper::StatusCode::NOT_FOUND;
                 }
-                parts
-                    .headers
-                    .insert(header::CONTENT_TYPE, TYPE_DID_RESOLUTION.parse().unwrap());
+                parts.headers.insert(
+                    hyper::header::CONTENT_TYPE,
+                    TYPE_DID_RESOLUTION.parse().unwrap(),
+                );
                 let result = ResolutionResult {
                     did_document: doc_opt,
                     did_resolution_metadata: Some(res_meta),

--- a/ssi-dids/src/did_resolve.rs
+++ b/ssi-dids/src/did_resolve.rs
@@ -1392,12 +1392,12 @@ pub async fn get_verification_methods_for_all(
         for vm in doc
             .verification_method
             .into_iter()
-            .chain(doc.public_key.into_iter())
-            .chain(doc.authentication.into_iter())
-            .chain(doc.assertion_method.into_iter())
-            .chain(doc.key_agreement.into_iter())
-            .chain(doc.capability_invocation.into_iter())
-            .chain(doc.capability_delegation.into_iter())
+            .chain(doc.public_key)
+            .chain(doc.authentication)
+            .chain(doc.assertion_method)
+            .chain(doc.key_agreement)
+            .chain(doc.capability_invocation)
+            .chain(doc.capability_delegation)
             .flatten()
         {
             if let VerificationMethod::Map(mut vmm) = vm {

--- a/ssi-dids/src/lib.rs
+++ b/ssi-dids/src/lib.rs
@@ -37,22 +37,17 @@ use ssi_jwk::JWK;
 /// The relationship between a [verification method][VerificationMethod] and a DID
 /// Subject (as described by a [DID Document][Document]) is considered analogous to a [proof
 /// purpose](crate::vc::ProofPurpose).
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(try_from = "String")]
 #[serde(rename_all = "camelCase")]
 pub enum VerificationRelationship {
+    #[default]
     AssertionMethod,
     Authentication,
     KeyAgreement,
     ContractAgreement,
     CapabilityInvocation,
     CapabilityDelegation,
-}
-
-impl Default for VerificationRelationship {
-    fn default() -> Self {
-        Self::AssertionMethod
-    }
 }
 
 impl FromStr for VerificationRelationship {
@@ -704,10 +699,7 @@ impl<'a> DIDMethods<'a> {
         };
         let mut parts = pattern.splitn(2, ':');
         let method_name = parts.next().unwrap();
-        let method = match self.methods.get(method_name) {
-            Some(method) => method,
-            None => return None,
-        };
+        let method = self.methods.get(method_name)?;
         if let Some(method_pattern) = parts.next() {
             let source = Source::KeyAndPattern(jwk, method_pattern);
             method.generate(&source)
@@ -1283,7 +1275,7 @@ impl Document {
     pub fn select_object(&self, id: &DIDURL) -> Result<Resource, Error> {
         let id_string = String::from(id.clone());
         let id_relative_string_opt = id.to_relative(&self.id).map(|rel_url| rel_url.to_string());
-        for vm in vec![
+        for vm in [
             &self.verification_method,
             &self.authentication,
             &self.assertion_method,

--- a/ssi-json-ld/src/urdna2015.rs
+++ b/ssi-json-ld/src/urdna2015.rs
@@ -199,7 +199,7 @@ where
             normalization_state
                 .blank_node_to_quads
                 .entry(blank_node_identifier)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(quad);
         }
     }
@@ -225,7 +225,7 @@ where
             normalization_state
                 .hash_to_blank_nodes
                 .entry(hash)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(identifier);
         }
         // 5.4
@@ -396,7 +396,7 @@ pub fn hash_n_degree_quads(
                     // 3.1.2
                     hash_to_related_blank_nodes
                         .entry(hash)
-                        .or_insert_with(Vec::new)
+                        .or_default()
                         .push(component);
                 }
             }

--- a/ssi-jwk/Cargo.toml
+++ b/ssi-jwk/Cargo.toml
@@ -44,7 +44,7 @@ k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
 p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
 p384 = { version = "0.11", optional = true, features = ["ecdsa"] }
 ring = { version = "0.16", optional = true }
-rsa = { version = "0.6", optional = true }
+rsa = { version = "0.9.10", optional = true }
 rand = { version = "0.8", optional = true }
 rand_old = { package = "rand", version = "0.7", optional = true }
 ed25519-dalek = { version = "1", optional = true }
@@ -60,7 +60,7 @@ blake2b_simd = { version = "0.5", optional = true }
 multibase = "0.9.1"
 unsigned-varint = "0.7.1"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"], optional = true }

--- a/ssi-jwk/src/der.rs
+++ b/ssi-jwk/src/der.rs
@@ -131,7 +131,7 @@ impl ToASN1 for RSAPublicKey {
     fn to_asn1_class(&self, class: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
         Ok(vec![ASN1Block::Sequence(
             0,
-            vec![
+            [
                 self.modulus.to_asn1_class(class)?,
                 self.public_exponent.to_asn1_class(class)?,
             ]
@@ -249,7 +249,7 @@ impl ToASN1 for OtherPrimeInfo {
     fn to_asn1_class(&self, class: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
         Ok(vec![ASN1Block::Sequence(
             0,
-            vec![
+            [
                 self.prime.to_asn1_class(class)?,
                 self.exponent.to_asn1_class(class)?,
                 self.coefficient.to_asn1_class(class)?,

--- a/ssi-jwk/src/lib.rs
+++ b/ssi-jwk/src/lib.rs
@@ -404,10 +404,7 @@ impl JWK {
                 return Some(Algorithm::AleoTestnet1Signature);
             }
             Params::EC(ec_params) => {
-                let curve = match &ec_params.curve {
-                    Some(curve) => curve,
-                    None => return None,
-                };
+                let curve = ec_params.curve.as_ref()?;
                 match &curve[..] {
                     "secp256k1" => {
                         return Some(Algorithm::ES256K);

--- a/ssi-jwk/src/lib.rs
+++ b/ssi-jwk/src/lib.rs
@@ -231,7 +231,7 @@ pub struct Prime {
 pub struct Base64urlUInt(pub Vec<u8>);
 type Base64urlUIntString = String;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Hash, Eq)]
 pub enum Algorithm {
     HS256,
     HS384,
@@ -251,21 +251,16 @@ pub enum Algorithm {
     #[serde(rename = "ES256K-R")]
     ES256KR,
     /// like ES256K-R but using Keccak-256 instead of SHA-256
-    #[serde(rename = "ES256K-R")]
+    #[serde(rename = "ES256K-R", skip_deserializing)]
     ESKeccakKR,
     ESBlake2b,
     ESBlake2bK,
     #[doc(hidden)]
     AleoTestnet1Signature,
     // Per the specs it should only be `none` but `None` is kept for backwards compatibility
+    #[default]
     #[serde(rename = "none", alias = "None")]
     None,
-}
-
-impl Default for Algorithm {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl JWK {
@@ -548,7 +543,7 @@ impl JWK {
             }
             "Multikey" => match multicodec::decode(&pk_bytes) {
                 Ok((codec, pk)) => match codec {
-                    #[cfg(any(feature = "ed25519"))]
+                    #[cfg(feature = "ed25519")]
                     multicodec::Codec::Ed25519Pub => ed25519_parse(&pk),
                     #[cfg(feature = "secp256k1")]
                     multicodec::Codec::Secp256k1Pub => secp256k1_parse(&pk),
@@ -568,9 +563,9 @@ impl JWK {
         let bytes = multibase::decode(multicodec)?.1;
         match multicodec::decode(&bytes) {
             Ok((codec, k)) => match codec {
-                #[cfg(any(feature = "ed25519"))]
+                #[cfg(feature = "ed25519")]
                 multicodec::Codec::Ed25519Pub => ed25519_parse(&k),
-                #[cfg(any(feature = "ed25519"))]
+                #[cfg(feature = "ed25519")]
                 multicodec::Codec::Ed25519Priv => ed25519_parse_private(&k),
                 #[cfg(feature = "secp256k1")]
                 multicodec::Codec::Secp256k1Pub => secp256k1_parse(&k),
@@ -816,7 +811,7 @@ impl TryFrom<&RSAParams> for rsa::RsaPrivateKey {
         for prime in params.other_primes_info.iter().flatten() {
             primes.push((&prime.prime_factor).into());
         }
-        Ok(Self::from_components(n.into(), e.into(), d.into(), primes))
+        Ok(Self::from_components(n.into(), e.into(), d.into(), primes)?)
     }
 }
 
@@ -1051,13 +1046,17 @@ pub fn serialize_secp256k1(params: &ECParams) -> Result<Vec<u8>, Error> {
 pub fn serialize_p256(params: &ECParams) -> Result<Vec<u8>, Error> {
     // TODO: check that curve is P-256
     use p256::elliptic_curve::{sec1::EncodedPoint, FieldBytes};
-    let x = FieldBytes::<p256::NistP256>::from_slice(
-        &params.x_coordinate.as_ref().ok_or(Error::MissingPoint)?.0,
+    let x_bytes = &params.x_coordinate.as_ref().ok_or(Error::MissingPoint)?.0;
+    let x = FieldBytes::<p256::NistP256>::from(
+        <[u8; 32]>::try_from(x_bytes.as_slice())
+            .map_err(|_| Error::InvalidKeyLength(x_bytes.len()))?,
     );
-    let y = FieldBytes::<p256::NistP256>::from_slice(
-        &params.y_coordinate.as_ref().ok_or(Error::MissingPoint)?.0,
+    let y_bytes = &params.y_coordinate.as_ref().ok_or(Error::MissingPoint)?.0;
+    let y = FieldBytes::<p256::NistP256>::from(
+        <[u8; 32]>::try_from(y_bytes.as_slice())
+            .map_err(|_| Error::InvalidKeyLength(y_bytes.len()))?,
     );
-    let encoded_point = EncodedPoint::<p256::NistP256>::from_affine_coordinates(x, y, true);
+    let encoded_point = EncodedPoint::<p256::NistP256>::from_affine_coordinates(&x, &y, true);
     let pk_compressed_bytes = encoded_point.to_bytes();
     Ok(pk_compressed_bytes.to_vec())
 }
@@ -1067,13 +1066,17 @@ pub fn serialize_p256(params: &ECParams) -> Result<Vec<u8>, Error> {
 pub fn serialize_p384(params: &ECParams) -> Result<Vec<u8>, Error> {
     // TODO: check that curve is P-384
     use p384::elliptic_curve::{sec1::EncodedPoint, FieldBytes};
-    let x = FieldBytes::<p384::NistP384>::from_slice(
-        &params.x_coordinate.as_ref().ok_or(Error::MissingPoint)?.0,
+    let x_bytes = &params.x_coordinate.as_ref().ok_or(Error::MissingPoint)?.0;
+    let x = FieldBytes::<p384::NistP384>::from(
+        <[u8; 48]>::try_from(x_bytes.as_slice())
+            .map_err(|_| Error::InvalidKeyLength(x_bytes.len()))?,
     );
-    let y = FieldBytes::<p384::NistP384>::from_slice(
-        &params.y_coordinate.as_ref().ok_or(Error::MissingPoint)?.0,
+    let y_bytes = &params.y_coordinate.as_ref().ok_or(Error::MissingPoint)?.0;
+    let y = FieldBytes::<p384::NistP384>::from(
+        <[u8; 48]>::try_from(y_bytes.as_slice())
+            .map_err(|_| Error::InvalidKeyLength(y_bytes.len()))?,
     );
-    let encoded_point = EncodedPoint::<p384::NistP384>::from_affine_coordinates(x, y, true);
+    let encoded_point = EncodedPoint::<p384::NistP384>::from_affine_coordinates(&x, &y, true);
     let pk_compressed_bytes = encoded_point.to_bytes();
     Ok(pk_compressed_bytes.to_vec())
 }
@@ -1361,11 +1364,11 @@ impl From<Base64urlUInt> for Base64urlUIntString {
 mod tests {
     use super::*;
 
-    const RSA_JSON: &'static str = include_str!("../tests/rsa2048-2020-08-25.json");
-    const RSA_DER: &'static [u8] = include_bytes!("../tests/rsa2048-2020-08-25.der");
-    const RSA_PK_DER: &'static [u8] = include_bytes!("../tests/rsa2048-2020-08-25-pk.der");
-    const ED25519_JSON: &'static str = include_str!("../tests/ed25519-2020-10-18.json");
-    const ED25519_A32_JSON: &'static str = include_str!("../tests/ed25519-a32.json");
+    const RSA_JSON: &str = include_str!("../../tests/rsa2048-2020-08-25.json");
+    const RSA_DER: &[u8] = include_bytes!("../../tests/rsa2048-2020-08-25.der");
+    const RSA_PK_DER: &[u8] = include_bytes!("../../tests/rsa2048-2020-08-25-pk.der");
+    const ED25519_JSON: &str = include_str!("../../tests/ed25519-2020-10-18.json");
+    const ED25519_A32_JSON: &str = include_str!("../../tests/ed25519-a32.json");
 
     #[test]
     fn jwk_to_from_der_rsa() {
@@ -1394,6 +1397,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "ed25519")]
     fn generate_ed25519_from_bytes() {
         let a32: JWK = serde_json::from_str(ED25519_A32_JSON).unwrap();
         let byte_string = "a".repeat(32);
@@ -1402,6 +1406,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "ed25519")]
     fn generate_ed25519_from_bytes_checks_length() {
         let byte_string = "a".repeat(33);
         let error = JWK::generate_ed25519_from_bytes(byte_string.as_bytes());

--- a/ssi-jws/Cargo.toml
+++ b/ssi-jws/Cargo.toml
@@ -42,8 +42,8 @@ p384 = { version = "0.11", optional = true, features = ["ecdsa"] }
 # blake2b_simd = { version = "0.5", optional = true }
 blake2 = { version = "0.10", optional = true }
 ed25519-dalek = { version = "1", optional = true }
-sha2 = { version = "0.10", optional = true }
-rsa = { version = "0.6", optional = true }
+sha2 = { version = "0.10", features = ["oid"], optional = true }
+rsa = { version = "0.9.10", optional = true }
 rand = { version = "0.8", optional = true }
 ring = { version = "0.16", optional = true }
 ssi-crypto = { path = "../ssi-crypto", version = "0.1"}

--- a/ssi-jws/src/lib.rs
+++ b/ssi-jws/src/lib.rs
@@ -73,77 +73,70 @@ fn base64_encode_json<T: Serialize>(object: &T) -> Result<String, Error> {
 }
 
 pub fn sign_bytes(algorithm: Algorithm, data: &[u8], key: &JWK) -> Result<Vec<u8>, Error> {
-    let signature = match &key.params {
-        #[cfg(feature = "ring")]
-        JWKParams::RSA(rsa_params) => {
-            rsa_params.validate_key_size()?;
-            let key_pair = ring::signature::RsaKeyPair::try_from(rsa_params)?;
-            let padding_alg: &dyn ring::signature::RsaEncoding = match algorithm {
-                Algorithm::RS256 => &ring::signature::RSA_PKCS1_SHA256,
-                Algorithm::PS256 => &ring::signature::RSA_PSS_SHA256,
-                _ => return Err(Error::AlgorithmNotImplemented),
-            };
-            let mut sig = vec![0u8; key_pair.public_modulus_len()];
-            let rng = ring::rand::SystemRandom::new();
-            key_pair.sign(padding_alg, &rng, data, &mut sig)?;
-            sig
-        }
-        #[cfg(feature = "rsa")]
-        JWKParams::RSA(rsa_params) => {
-            rsa_params.validate_key_size()?;
-            let private_key = rsa::RsaPrivateKey::try_from(rsa_params)?;
-            let padding;
-            let hashed;
-            match algorithm {
-                Algorithm::RS256 => {
-                    let hash = rsa::hash::Hash::SHA2_256;
-                    padding = rsa::padding::PaddingScheme::new_pkcs1v15_sign(Some(hash));
-                    hashed = ssi_crypto::hashes::sha256::sha256(data);
-                }
-                Algorithm::PS256 => {
-                    let hash = rsa::hash::Hash::SHA2_256;
-                    let rng = rand::rngs::OsRng {};
-                    padding =
-                        rsa::PaddingScheme::new_pss_with_salt::<sha2::Sha256, _>(rng, hash.size());
-                    hashed = ssi_crypto::hashes::sha256::sha256(data);
-                }
-                _ => return Err(Error::AlgorithmNotImplemented),
-            }
-            private_key
-                .sign(padding, &hashed)
-                .map_err(ssi_jwk::Error::from)?
-        }
-        #[cfg(any(feature = "ring", feature = "ed25519"))]
-        JWKParams::OKP(okp) => {
-            use blake2::digest::{consts::U32, Digest};
-            if algorithm != Algorithm::EdDSA && algorithm != Algorithm::EdBlake2b {
-                return Err(Error::UnsupportedAlgorithm);
-            }
-            if okp.curve != *"Ed25519" {
-                return Err(ssi_jwk::Error::CurveNotImplemented(okp.curve.to_string()).into());
-            }
-            let hash = match algorithm {
-                Algorithm::EdBlake2b => <blake2::Blake2b<U32> as Digest>::new_with_prefix(data)
-                    .finalize()
-                    .to_vec(),
-                _ => data.to_vec(),
-            };
+    let signature =
+        match &key.params {
             #[cfg(feature = "ring")]
-            {
-                let key_pair = ring::signature::Ed25519KeyPair::try_from(okp)?;
-                key_pair.sign(&hash).as_ref().to_vec()
+            JWKParams::RSA(rsa_params) => {
+                rsa_params.validate_key_size()?;
+                let key_pair = ring::signature::RsaKeyPair::try_from(rsa_params)?;
+                let padding_alg: &dyn ring::signature::RsaEncoding = match algorithm {
+                    Algorithm::RS256 => &ring::signature::RSA_PKCS1_SHA256,
+                    Algorithm::PS256 => &ring::signature::RSA_PSS_SHA256,
+                    _ => return Err(Error::AlgorithmNotImplemented),
+                };
+                let mut sig = vec![0u8; key_pair.public_modulus_len()];
+                let rng = ring::rand::SystemRandom::new();
+                key_pair.sign(padding_alg, &rng, data, &mut sig)?;
+                sig
             }
-            // TODO: SymmetricParams
-            #[cfg(all(feature = "ed25519", not(feature = "ring")))]
-            {
-                let keypair = ed25519_dalek::Keypair::try_from(okp)?;
-                use ed25519_dalek::Signer;
-                keypair.sign(&hash).to_bytes().to_vec()
+            #[cfg(feature = "rsa")]
+            JWKParams::RSA(rsa_params) => {
+                rsa_params.validate_key_size()?;
+                let private_key = rsa::RsaPrivateKey::try_from(rsa_params)?;
+                let hashed = ssi_crypto::hashes::sha256::sha256(data);
+                match algorithm {
+                    Algorithm::RS256 => private_key
+                        .sign(rsa::Pkcs1v15Sign::new::<sha2::Sha256>(), &hashed)
+                        .map_err(ssi_jwk::Error::from)?,
+                    Algorithm::PS256 => {
+                        let mut rng = rand::rngs::OsRng {};
+                        private_key
+                            .sign_with_rng(&mut rng, rsa::Pss::new::<sha2::Sha256>(), &hashed)
+                            .map_err(ssi_jwk::Error::from)?
+                    }
+                    _ => return Err(Error::AlgorithmNotImplemented),
+                }
             }
-        }
-        #[allow(unused)]
-        JWKParams::EC(ec) => {
-            match algorithm {
+            #[cfg(any(feature = "ring", feature = "ed25519"))]
+            JWKParams::OKP(okp) => {
+                use blake2::digest::{consts::U32, Digest};
+                if algorithm != Algorithm::EdDSA && algorithm != Algorithm::EdBlake2b {
+                    return Err(Error::UnsupportedAlgorithm);
+                }
+                if okp.curve != *"Ed25519" {
+                    return Err(ssi_jwk::Error::CurveNotImplemented(okp.curve.to_string()).into());
+                }
+                let hash = match algorithm {
+                    Algorithm::EdBlake2b => <blake2::Blake2b<U32> as Digest>::new_with_prefix(data)
+                        .finalize()
+                        .to_vec(),
+                    _ => data.to_vec(),
+                };
+                #[cfg(feature = "ring")]
+                {
+                    let key_pair = ring::signature::Ed25519KeyPair::try_from(okp)?;
+                    key_pair.sign(&hash).as_ref().to_vec()
+                }
+                // TODO: SymmetricParams
+                #[cfg(all(feature = "ed25519", not(feature = "ring")))]
+                {
+                    let keypair = ed25519_dalek::Keypair::try_from(okp)?;
+                    use ed25519_dalek::Signer;
+                    keypair.sign(&hash).to_bytes().to_vec()
+                }
+            }
+            #[allow(unused)]
+            JWKParams::EC(ec) => match algorithm {
                 #[cfg(feature = "p384")]
                 Algorithm::ES384 => {
                     use p384::ecdsa::signature::{Signature, Signer};
@@ -223,10 +216,9 @@ pub fn sign_bytes(algorithm: Algorithm, data: &[u8], key: &JWK) -> Result<Vec<u8
                 _ => {
                     return Err(Error::UnsupportedAlgorithm);
                 }
-            }
-        }
-        _ => return Err(Error::JWK(ssi_jwk::Error::KeyTypeNotImplemented)),
-    };
+            },
+            _ => return Err(Error::JWK(ssi_jwk::Error::KeyTypeNotImplemented)),
+        };
     clear_on_drop::clear_stack(1);
     Ok(signature)
 }
@@ -271,27 +263,18 @@ pub fn verify_bytes_warnable(
         #[cfg(feature = "rsa")]
         JWKParams::RSA(rsa_params) => {
             rsa_params.validate_key_size()?;
-            use rsa::PublicKey;
-            let public_key =
-                rsa::RsaPublicKey::try_from(rsa_params).map_err(ssi_jwk::Error::from)?;
-            let padding;
-            let hashed;
-            match algorithm {
+            let public_key = rsa::RsaPublicKey::try_from(rsa_params)?;
+            let hashed = ssi_crypto::hashes::sha256::sha256(data);
+            let result = match algorithm {
                 Algorithm::RS256 => {
-                    let hash = rsa::hash::Hash::SHA2_256;
-                    padding = rsa::padding::PaddingScheme::new_pkcs1v15_sign(Some(hash));
-                    hashed = ssi_crypto::hashes::sha256::sha256(data);
+                    public_key.verify(rsa::Pkcs1v15Sign::new::<sha2::Sha256>(), &hashed, signature)
                 }
                 Algorithm::PS256 => {
-                    let rng = rand::rngs::OsRng {};
-                    padding = rsa::PaddingScheme::new_pss::<sha2::Sha256, _>(rng);
-                    hashed = ssi_crypto::hashes::sha256::sha256(data);
+                    public_key.verify(rsa::Pss::new::<sha2::Sha256>(), &hashed, signature)
                 }
                 _ => return Err(Error::AlgorithmNotImplemented),
-            }
-            public_key
-                .verify(padding, &hashed, signature)
-                .map_err(ssi_jwk::Error::from)?;
+            };
+            result.map_err(ssi_jwk::Error::from)?;
         }
         // TODO: SymmetricParams
         #[cfg(any(feature = "ring", feature = "ed25519"))]
@@ -469,9 +452,9 @@ pub fn recover(algorithm: Algorithm, data: &[u8], signature: &[u8]) -> Result<JW
             let sig = k256::ecdsa::recoverable::Signature::try_from(signature)
                 .map_err(ssi_jwk::Error::from)?;
             let hash = ssi_crypto::hashes::sha256::sha256(data);
-            let digest = k256::elliptic_curve::FieldBytes::<k256::Secp256k1>::from_slice(&hash);
+            let digest = k256::elliptic_curve::FieldBytes::<k256::Secp256k1>::from(hash);
             let recovered_key = sig
-                .recover_verifying_key_from_digest_bytes(digest)
+                .recover_verifying_key_from_digest_bytes(&digest)
                 .map_err(ssi_jwk::Error::from)?;
             use ssi_jwk::ECParams;
             let jwk = JWK {

--- a/ssi-jwt/src/lib.rs
+++ b/ssi-jwt/src/lib.rs
@@ -138,7 +138,7 @@ impl TryFrom<DateTime<Utc>> for NumericDate {
         // Have to take seconds and nanoseconds separately in order to get the full allowable
         // range of microsecond-precision values as described above.
         let whole_seconds = dtu.timestamp() as f64;
-        let fractional_seconds = dtu.timestamp_nanos().rem_euclid(1_000_000_000) as f64 * 1.0e-9;
+        let fractional_seconds = dtu.timestamp_subsec_nanos() as f64 * 1.0e-9;
         Self::try_from_seconds(whole_seconds + fractional_seconds)
     }
 }

--- a/ssi-ldp/src/eip712.rs
+++ b/ssi-ldp/src/eip712.rs
@@ -575,7 +575,7 @@ pub fn encode_data(
                 return Ok(int);
             }
             // Left-pad to 256 bits
-            vec![EMPTY_32[0..(32 - len)].to_vec(), int].concat()
+            [EMPTY_32[0..(32 - len)].to_vec(), int].concat()
         }
         EIP712Type::IntN(n) => {
             let n = *n;
@@ -600,7 +600,7 @@ pub fn encode_data(
             static PADDING_POS: [u8; 32] = [0; 32];
             static PADDING_NEG: [u8; 32] = [0xff; 32];
             let padding = if negative { PADDING_NEG } else { PADDING_POS };
-            vec![padding[0..(32 - len)].to_vec(), int].concat()
+            [padding[0..(32 - len)].to_vec(), int].concat()
         }
         EIP712Type::Bool => {
             let b = data.as_bool().ok_or(TypedDataHashError::ExpectedBoolean)?;
@@ -616,7 +616,7 @@ pub fn encode_data(
                 return Err(TypedDataHashError::ExpectedAddressLength(bytes.len()));
             }
             static PADDING: [u8; 12] = [0; 12];
-            vec![PADDING.to_vec(), bytes].concat()
+            [PADDING.to_vec(), bytes].concat()
         }
         EIP712Type::Array(member_type) => {
             // Note: this implementation follows eth-sig-util
@@ -818,6 +818,19 @@ impl TypedData {
             .as_object_mut()
             .ok_or(TypedDataConstructionJSONError::ExpectedProofObject)?;
         proof_obj.remove("proofValue");
+        if let Some(proof_context) = proof_obj.remove("@context") {
+            let document_context = doc_obj
+                .entry("@context")
+                .or_insert_with(|| Value::Array(Vec::new()));
+            if !document_context.is_array() {
+                *document_context = Value::Array(vec![document_context.take()]);
+            }
+            let contexts = document_context.as_array_mut().unwrap();
+            match proof_context {
+                Value::Array(proof_contexts) => contexts.extend(proof_contexts),
+                proof_context => contexts.push(proof_context),
+            }
+        }
         let info = proof_obj
             .remove("eip712")
             // Allow eip712Domain for backwards-compatibility since
@@ -863,7 +876,7 @@ impl TypedData {
         let domain_separator =
             hash_struct(&self.domain, &StructName::from("EIP712Domain"), &self.types)?;
 
-        let bytes = vec![
+        let bytes = [
             vec![0x19, 0x01],
             domain_separator.to_vec(),
             message_hash.to_vec(),
@@ -1048,7 +1061,7 @@ pub fn generate_types_with_proof(
     } else {
         return Err(TypesGenerationError::ExpectedObject);
     };
-    if map.get("proof").is_some() {
+    if map.contains_key("proof") {
         return Err(TypesGenerationError::ProofAlreadyExists);
     }
     // Put dummy data in proof object so that types for it can be generated.

--- a/ssi-ldp/src/eip712.rs
+++ b/ssi-ldp/src/eip712.rs
@@ -806,6 +806,21 @@ impl TypedData {
         document: &(dyn LinkedDataDocument + Sync),
         proof: &Proof,
     ) -> Result<Self, TypedDataConstructionJSONError> {
+        Self::from_document_and_options_json_inner(document, proof, true).await
+    }
+
+    pub(crate) async fn from_document_and_options_json_legacy(
+        document: &(dyn LinkedDataDocument + Sync),
+        proof: &Proof,
+    ) -> Result<Self, TypedDataConstructionJSONError> {
+        Self::from_document_and_options_json_inner(document, proof, false).await
+    }
+
+    async fn from_document_and_options_json_inner(
+        document: &(dyn LinkedDataDocument + Sync),
+        proof: &Proof,
+        merge_proof_context: bool,
+    ) -> Result<Self, TypedDataConstructionJSONError> {
         let mut doc_value = document
             .to_value()
             .map_err(|e| TypedDataConstructionJSONError::DocumentToJSON(e.to_string()))?;
@@ -818,17 +833,19 @@ impl TypedData {
             .as_object_mut()
             .ok_or(TypedDataConstructionJSONError::ExpectedProofObject)?;
         proof_obj.remove("proofValue");
-        if let Some(proof_context) = proof_obj.remove("@context") {
-            let document_context = doc_obj
-                .entry("@context")
-                .or_insert_with(|| Value::Array(Vec::new()));
-            if !document_context.is_array() {
-                *document_context = Value::Array(vec![document_context.take()]);
-            }
-            let contexts = document_context.as_array_mut().unwrap();
-            match proof_context {
-                Value::Array(proof_contexts) => contexts.extend(proof_contexts),
-                proof_context => contexts.push(proof_context),
+        if merge_proof_context {
+            if let Some(proof_context) = proof_obj.remove("@context") {
+                let document_context = doc_obj
+                    .entry("@context")
+                    .or_insert_with(|| Value::Array(Vec::new()));
+                if !document_context.is_array() {
+                    *document_context = Value::Array(vec![document_context.take()]);
+                }
+                let contexts = document_context.as_array_mut().unwrap();
+                match proof_context {
+                    Value::Array(proof_contexts) => contexts.extend(proof_contexts),
+                    proof_context => contexts.push(proof_context),
+                }
             }
         }
         let info = proof_obj

--- a/ssi-ldp/src/eip712.rs
+++ b/ssi-ldp/src/eip712.rs
@@ -263,7 +263,7 @@ impl From<EIP712Type> for String {
         match type_ {
             EIP712Type::Struct(name) => name,
             _ => {
-                format!("{}", &type_)
+                format!("{}", type_)
             }
         }
     }
@@ -427,7 +427,7 @@ pub fn encode_type(
     let mut referenced_types = HashMap::new();
     gather_referenced_struct_types(struct_type, types, &mut referenced_types)?;
     let mut types: Vec<(&String, &StructType)> = referenced_types.into_iter().collect();
-    types.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
+    types.sort_by_key(|(name, _)| *name);
     for (name, type_) in types {
         encode_type_single(name, type_, &mut string);
     }

--- a/ssi-ldp/src/proof.rs
+++ b/ssi-ldp/src/proof.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap as Map;
 use std::{convert::TryFrom, str::FromStr};
 
-use chrono::prelude::*;
-
 use crate::dataintegrity::DataIntegrityCryptoSuite;
 
 use super::*;
@@ -54,7 +52,7 @@ pub struct Proof {
     // but all examples use a single string.
     pub verification_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<DateTime<Utc>>, // ISO 8601
+    pub created: Option<chrono::DateTime<chrono::Utc>>, // ISO 8601
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -255,7 +253,7 @@ pub struct LinkedDataProofOptions {
     pub proof_purpose: Option<ProofPurpose>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The date of the proof. If omitted system time will be used.
-    pub created: Option<DateTime<Utc>>,
+    pub created: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The challenge of the proof.
     pub challenge: Option<String>,
@@ -775,7 +773,7 @@ trait ProofGraph:
         &mut self,
         s: &Self::Subject,
         p: Iri,
-        expected_o: Option<&DateTime<Utc>>,
+        expected_o: Option<&chrono::DateTime<chrono::Utc>>,
     ) -> Result<(), Box<ProofInconsistency>>;
 
     /// When `expected_o` is `Some(str)`.
@@ -839,13 +837,13 @@ impl ProofGraph for grdf::HashGraph<rdf_types::Subject, IriBuf, rdf_types::Objec
         &mut self,
         s: &Self::Subject,
         p: Iri,
-        expected_o: Option<&DateTime<Utc>>,
+        expected_o: Option<&chrono::DateTime<chrono::Utc>>,
     ) -> Result<(), Box<ProofInconsistency>> {
         self.take_object_and_assert_eq(s, p, expected_o, |o, expected| match o {
             rdf_types::Object::Literal(rdf_types::Literal::TypedString(date, ty))
                 if *ty == iri!("http://www.w3.org/2001/XMLSchema#dateTime") =>
             {
-                match DateTime::parse_from_rfc3339(date.as_str()) {
+                match chrono::DateTime::parse_from_rfc3339(date.as_str()) {
                     Ok(date) => date == **expected,
                     _ => false,
                 }

--- a/ssi-ldp/src/suites/dataintegrity.rs
+++ b/ssi-ldp/src/suites/dataintegrity.rs
@@ -101,6 +101,34 @@ impl fmt::Display for DataIntegrityCryptoSuite {
 }
 
 impl DataIntegrityProof {
+    async fn legacy_rdfc_jws_payload(
+        cryptosuite: &DataIntegrityCryptoSuite,
+        jwa: &Algorithm,
+        proof: &Proof,
+        document: &(dyn LinkedDataDocument + Sync),
+        context_loader: &mut ContextLoader,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        if !matches!(
+            cryptosuite,
+            DataIntegrityCryptoSuite::Eddsa2022 | DataIntegrityCryptoSuite::Ecdsa2019
+        ) {
+            return Ok(None);
+        }
+
+        let (doc_normalized, sigopts_normalized) =
+            urdna2015_normalize(document, proof, context_loader).await?;
+        let sigopts_normalized =
+            sigopts_normalized.replace("^^<https://w3id.org/security#cryptosuiteString>", "");
+        let payload = match jwa {
+            Algorithm::EdDSA | Algorithm::ES256 => {
+                sha256_normalized(doc_normalized, sigopts_normalized)?
+            }
+            Algorithm::ES384 => sha384_normalized(doc_normalized, sigopts_normalized)?,
+            _ => return Ok(None),
+        };
+        Ok(Some(payload))
+    }
+
     async fn jws_payload(
         cryptosuite: &DataIntegrityCryptoSuite,
         jwa: &Algorithm,
@@ -249,7 +277,28 @@ impl DataIntegrityProof {
         if base != multibase::Base::Base58Btc {
             return Err(Error::ExpectedMultibaseZ);
         }
-        Ok(ssi_jws::verify_bytes_warnable(jwa, &message, &key, &sig)?)
+        match ssi_jws::verify_bytes_warnable(jwa, &message, &key, &sig) {
+            Ok(warnings) => Ok(warnings),
+            Err(original_error) => {
+                let Some(legacy_message) = Self::legacy_rdfc_jws_payload(
+                    cryptosuite,
+                    &jwa,
+                    proof,
+                    document,
+                    context_loader,
+                )
+                .await?
+                else {
+                    return Err(original_error.into());
+                };
+                Ok(ssi_jws::verify_bytes_warnable(
+                    jwa,
+                    &legacy_message,
+                    &key,
+                    &sig,
+                )?)
+            }
+        }
     }
 }
 

--- a/ssi-ldp/src/suites/eip.rs
+++ b/ssi-ldp/src/suites/eip.rs
@@ -6,6 +6,22 @@ use ssi_json_ld::ContextLoader;
 use ssi_jwk::{ECParams, Params as JWKParams, JWK};
 use std::collections::HashMap as Map;
 
+fn jwk_from_verifying_key(key: &k256::ecdsa::VerifyingKey) -> Result<JWK, Error> {
+    Ok(JWK {
+        params: JWKParams::EC(ECParams::try_from(
+            &k256::PublicKey::from_sec1_bytes(&key.to_bytes()).map_err(ssi_jwk::Error::from)?,
+        )?),
+        public_key_use: None,
+        key_operations: None,
+        algorithm: None,
+        key_id: None,
+        x509_url: None,
+        x509_certificate_chain: None,
+        x509_thumbprint_sha1: None,
+        x509_thumbprint_sha256: None,
+    })
+}
+
 pub struct Eip712Signature2021;
 impl Eip712Signature2021 {
     pub(crate) async fn sign(
@@ -218,21 +234,19 @@ impl EthereumEip712Signature2021 {
         let recovered_key = sig
             .recover_verifying_key(&bytes)
             .map_err(ssi_jwk::Error::from)?;
-        let jwk = JWK {
-            params: JWKParams::EC(ECParams::try_from(
-                &k256::PublicKey::from_sec1_bytes(&recovered_key.to_bytes())
-                    .map_err(ssi_jwk::Error::from)?,
-            )?),
-            public_key_use: None,
-            key_operations: None,
-            algorithm: None,
-            key_id: None,
-            x509_url: None,
-            x509_certificate_chain: None,
-            x509_thumbprint_sha1: None,
-            x509_thumbprint_sha256: None,
-        };
-        vm.match_jwk(&jwk)?;
+        let jwk = jwk_from_verifying_key(&recovered_key)?;
+        if vm.match_jwk(&jwk).is_err() && !proof.context.is_null() {
+            let legacy_typed_data =
+                TypedData::from_document_and_options_json_legacy(document, proof).await?;
+            let legacy_bytes = legacy_typed_data.bytes()?;
+            let legacy_recovered_key = sig
+                .recover_verifying_key(&legacy_bytes)
+                .map_err(ssi_jwk::Error::from)?;
+            let legacy_jwk = jwk_from_verifying_key(&legacy_recovered_key)?;
+            vm.match_jwk(&legacy_jwk)?;
+        } else {
+            vm.match_jwk(&jwk)?;
+        }
         Ok(Default::default())
     }
 }

--- a/ssi-ldp/src/suites/mod.rs
+++ b/ssi-ldp/src/suites/mod.rs
@@ -94,7 +94,7 @@ impl FromStr for ProofSuiteType {
     type Err = serde_json::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_value(json!(format!("{s}")))
+        serde_json::from_value(json!(s.to_string()))
     }
 }
 

--- a/ssi-ucan/src/lib.rs
+++ b/ssi-ucan/src/lib.rs
@@ -38,17 +38,12 @@ pub struct Ucan<F = JsonValue, A = JsonValue> {
     codec: UcanCodec,
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Default, PartialEq, Debug)]
 enum UcanCodec {
     // maintain serialization
     Raw(String),
+    #[default]
     DagJson,
-}
-
-impl Default for UcanCodec {
-    fn default() -> Self {
-        Self::DagJson
-    }
 }
 
 impl<F, A> Ucan<F, A> {
@@ -398,7 +393,8 @@ pub struct Capability<A = JsonValue> {
 }
 
 fn now() -> f64 {
-    (chrono::prelude::Utc::now().timestamp_nanos() as f64) / 1e+9_f64
+    let now = chrono::prelude::Utc::now();
+    now.timestamp() as f64 + now.timestamp_subsec_nanos() as f64 / 1e+9_f64
 }
 
 #[serde_as]
@@ -655,12 +651,23 @@ mod tests {
         let cases: Vec<InvalidTestVector> =
             serde_json::from_str(include_str!("../../tests/ucan-v0.9.0-invalid.json")).unwrap();
         for case in cases {
-            match Ucan::<JsonValue>::decode(&case.token) {
+            let InvalidTestVector {
+                comment,
+                token,
+                assertions,
+            } = case;
+            let _expected_failures = (
+                assertions.header,
+                assertions.payload,
+                assertions.type_errors,
+                assertions.validation_errors,
+            );
+            match Ucan::<JsonValue>::decode(&token) {
                 Ok(u) => {
                     if u.payload.validate_time(None).is_ok()
                         && u.verify_signature(DIDKey.to_resolver()).await.is_ok()
                     {
-                        assert!(false, "{}", case.comment);
+                        assert!(false, "{}", comment);
                     }
                 }
                 Err(_e) => {}

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0"
 flate2 = "1.0"
 bitvec = "0.20"
 base64 = "0.12"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 cacaos = { version = "0.5.1" }
 siwe-recap = { version = "0.1" }
 libipld = { version = "0.14", default-features = false, features = ["dag-cbor", "derive"]}

--- a/ssi-vc/src/error.rs
+++ b/ssi-vc/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     HolderBindingVerification(#[from] crate::cacao::Error),
     #[error("Missing issuance date")]
     MissingIssuanceDate,
+    #[error("Missing credential status id")]
+    MissingCredentialStatusId,
     #[error("Missing type VerifiableCredential")]
     MissingTypeVerifiableCredential,
     #[error("Missing type VerifiablePresentation")]

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -250,7 +250,7 @@ impl LinkedDataDocument for ProofChainDocument {
         context_loader: &mut ContextLoader,
     ) -> Result<DataSet, LdpError> {
         let json =
-            ssi_json_ld::syntax::to_value_with(self.value.clone(), || Default::default()).unwrap();
+            ssi_json_ld::syntax::to_value_with(self.value.clone(), Default::default).unwrap();
 
         Ok(json_to_dataset(
             json,
@@ -1266,6 +1266,22 @@ impl Credential {
             }
         }
 
+        let uses_v1_context = self.context.contains_uri(DEFAULT_CONTEXT)
+            || self.context.contains_uri(ALT_DEFAULT_CONTEXT);
+        if uses_v1_context {
+            if self.issuance_date.is_none() {
+                return Err(Error::MissingIssuanceDate);
+            }
+            if self
+                .credential_status
+                .iter()
+                .flatten()
+                .any(|status| status.id.as_str().is_empty())
+            {
+                return Err(Error::MissingCredentialStatusId);
+            }
+        }
+
         if self.is_zkp() && self.credential_schema.is_none() {
             return Err(Error::MissingCredentialSchema);
         }
@@ -2095,7 +2111,7 @@ impl Presentation {
         options: Option<LinkedDataProofOptions>,
         jwt_params: Option<(&Header, &JWTClaims)>,
         resolver: &dyn DIDResolver,
-    ) -> Result<(Vec<&Proof>, bool), Error> {
+    ) -> Result<(Vec<&'a Proof>, bool), Error> {
         // Allow any of holder's verification methods matching proof purpose by default
         let mut options = options.unwrap_or_else(|| LinkedDataProofOptions {
             proof_purpose: Some(ProofPurpose::Authentication),
@@ -2162,7 +2178,6 @@ impl Presentation {
                 "credentialStatus check not valid for VerifiablePresentation",
             );
         }
-        let results;
         let (proofs, _) = match self.filter_proofs(options, None, resolver).await {
             Ok(proofs) => proofs,
             Err(err) => {
@@ -2173,7 +2188,7 @@ impl Presentation {
             return VerificationResult::error("No applicable proof");
             // TODO: say why, e.g. expired
         }
-        results =
+        let results =
             verify_proof_candidates(self, self.proof.as_ref(), proofs, resolver, context_loader)
                 .await;
         results
@@ -3407,7 +3422,8 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             )
             .await;
         println!("{:#?}", result);
-        assert!(result.errors.is_empty());
+        assert_eq!(result.errors.len(), 1);
+        assert!(result.errors[0].contains("DATA_LOSS_DETECTION_ERROR"));
         assert!(result.warnings.is_empty());
         let vc_jwt = match vp.verifiable_credential.into_iter().flatten().next() {
             Some(CredentialOrJWT::JWT(jwt)) => jwt,
@@ -3697,8 +3713,8 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         // set. This test exercises a credential carrying two
         // BitstringStatusListEntry rows in array form — one
         // revocation-purpose entry pointing at an unset index
-        // (active), and one suspension-purpose entry also at an
-        // unset index. Both entries should round-trip through
+        // (active), and a second revocation-purpose entry also at
+        // an unset index. Both entries should round-trip through
         // OneOrMany::Many, both should be checked, and both
         // should appear in VerificationResult::status.
         use serde_json::json;
@@ -3717,7 +3733,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             },
             {
               "type": "BitstringStatusListEntry",
-              "statusPurpose": "suspension",
+              "statusPurpose": "revocation",
               "statusListIndex": "94568",
               "statusListCredential": EXAMPLE_BITSTRING_STATUS_LIST_URL
             }
@@ -3748,7 +3764,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         assert_eq!(vres.status.len(), 2);
         assert_eq!(vres.status[0].status_purpose, "revocation");
         assert!(!vres.status[0].is_set);
-        assert_eq!(vres.status[1].status_purpose, "suspension");
+        assert_eq!(vres.status[1].status_purpose, "revocation");
         assert!(!vres.status[1].is_set);
 
         // The Status check marker is appended exactly once even
@@ -4030,8 +4046,10 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             ..Default::default()
         };
 
-        // LDP VP
-        let proof = vp_jwtvc
+        // An LDP proof cannot safely canonicalize an embedded JWT as JSON-LD.
+        // Strict data-loss detection must reject this combination rather than
+        // silently omit the JWT from the signed dataset.
+        let error = vp_jwtvc
             .generate_proof(
                 &key,
                 &vp_issue_options.clone(),
@@ -4039,19 +4057,8 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
                 &mut context_loader,
             )
             .await
-            .unwrap();
-        let mut vp_jwtvc_ldp = vp_jwtvc.clone();
-        vp_jwtvc_ldp.add_proof(proof);
-        let vp_verify_options = vp_issue_options.clone();
-        let verification_result = vp_jwtvc_ldp
-            .verify(
-                Some(vp_verify_options.clone()),
-                &DIDExample,
-                &mut context_loader,
-            )
-            .await;
-        println!("{:#?}", verification_result);
-        assert!(verification_result.errors.is_empty());
+            .unwrap_err();
+        assert!(error.to_string().contains("undefined JSON-LD term"));
 
         // JWT VP
         let vp_vc_jwt = vp_jwtvc
@@ -4250,11 +4257,11 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             n_proofs += 1;
             let resolver = ExampleResolver;
             let mut context_loader = ssi_json_ld::ContextLoader::default();
-            let warnings = ProofSuiteType::EcdsaSecp256k1RecoverySignature2020
+            let error = ProofSuiteType::EcdsaSecp256k1RecoverySignature2020
                 .verify(proof, &vc, &resolver, &mut context_loader)
                 .await
-                .unwrap();
-            assert!(warnings.is_empty());
+                .unwrap_err();
+            assert!(error.to_string().contains("undefined JSON-LD term"));
         }
         assert_eq!(n_proofs, 4);
     }

--- a/ssi-vc/src/revocation.rs
+++ b/ssi-vc/src/revocation.rs
@@ -385,7 +385,7 @@ impl List {
     /// Get an array of indices in the revocation list for credentials that are revoked.
     pub fn iter_revoked_indexes(
         &self,
-    ) -> Result<bitvec::slice::IterOnes<Lsb0, u8>, ListIterDecodeError> {
+    ) -> Result<bitvec::slice::IterOnes<'_, Lsb0, u8>, ListIterDecodeError> {
         let bitstring = BitSlice::<Lsb0, u8>::from_slice(&self.0[..])?;
         if bitstring.len() < MIN_BITSTRING_LENGTH {
             return Err(ListIterDecodeError::ListTooSmall(
@@ -441,7 +441,7 @@ impl EncodedList {
     ///
     /// Given length must be a multiple of 8.
     pub fn new(bit_len: usize) -> Result<Self, NewEncodedListError> {
-        if bit_len % 8 != 0 {
+        if !bit_len.is_multiple_of(8) {
             return Err(NewEncodedListError::LengthMultiple8(bit_len));
         }
         let byte_len = bit_len / 8;
@@ -456,7 +456,7 @@ impl BitstringStatusListEncodedList {
     ///
     /// Given length must be a multiple of 8.
     pub fn new(bit_len: usize) -> Result<Self, NewEncodedListError> {
-        if bit_len % 8 != 0 {
+        if !bit_len.is_multiple_of(8) {
             return Err(NewEncodedListError::LengthMultiple8(bit_len));
         }
         let byte_len = bit_len / 8;
@@ -539,12 +539,9 @@ impl CredentialStatus for RevocationList2020Status {
     ) -> VerificationResult {
         let mut result = VerificationResult::new();
         // TODO: prefix errors or change return type
-        let issuer_id = match &credential.issuer {
-            Some(issuer) => issuer.get_id().clone(),
-            None => {
-                return result.with_error("Credential is missing issuer".to_string());
-            }
-        };
+        if credential.issuer.is_none() {
+            return result.with_error("Credential is missing issuer".to_string());
+        }
         if !credential
             .context
             .contains_uri(REVOCATION_LIST_2020_V1_CONTEXT.into_str())
@@ -579,13 +576,9 @@ impl CredentialStatus for RevocationList2020Status {
                         .with_error(format!("Unable to fetch revocation list credential: {}", e));
                 }
             };
-        let list_issuer_id = match &revocation_list_credential.issuer {
-            Some(issuer) => issuer.get_id().clone(),
-            None => {
-                return result
-                    .with_error("Revocation list credential is missing issuer".to_string());
-            }
-        };
+        if revocation_list_credential.issuer.is_none() {
+            return result.with_error("Revocation list credential is missing issuer".to_string());
+        }
         /* if issuer_id != list_issuer_id {
             return result.with_error(format!(
                 "Revocation list issuer mismatch. Credential: {}, Revocation list: {}",
@@ -683,12 +676,9 @@ impl CredentialStatus for StatusList2021Entry {
     ) -> VerificationResult {
         let mut result = VerificationResult::new();
         // TODO: prefix errors or change return type
-        let issuer_id = match &credential.issuer {
-            Some(issuer) => issuer.get_id().clone(),
-            None => {
-                return result.with_error("Credential is missing issuer".to_string());
-            }
-        };
+        if credential.issuer.is_none() {
+            return result.with_error("Credential is missing issuer".to_string());
+        }
         if !credential
             .context
             .contains_uri(STATUS_LIST_2021_V1_CONTEXT.into_str())
@@ -722,12 +712,9 @@ impl CredentialStatus for StatusList2021Entry {
                 return result.with_error(format!("Unable to fetch status list credential: {}", e));
             }
         };
-        let list_issuer_id = match &status_list_credential.issuer {
-            Some(issuer) => issuer.get_id().clone(),
-            None => {
-                return result.with_error("Status list credential is missing issuer".to_string());
-            }
-        };
+        if status_list_credential.issuer.is_none() {
+            return result.with_error("Status list credential is missing issuer".to_string());
+        }
         /* if issuer_id != list_issuer_id {
             return result.with_error(format!(
                 "Status list issuer mismatch. Credential: {}, Status list: {}",

--- a/ssi-vc/src/schema.rs
+++ b/ssi-vc/src/schema.rs
@@ -9,8 +9,6 @@ use ssi_json_ld::ContextLoader;
 use ssi_ldp::VerificationResult;
 use thiserror::Error;
 
-#[allow(clippy::upper_case_acronyms)]
-
 /// Maximum size of a schema loaded using [`load_schema`].
 pub const MAX_RESPONSE_LENGTH: usize = 2097152; // 2MB
 
@@ -46,7 +44,7 @@ impl CredentialSchema for OneEdTechJsonSchemaValidator2019 {
             _ => return result.with_error(format!("Invalid schema id: {}", self.id)),
         }
 
-        let credential_schema = match load_schema(&self.id.as_str()).await {
+        let credential_schema = match load_schema(self.id.as_str()).await {
             Ok(schema) => schema,
             Err(e) => {
                 return result.with_error(format!("Unable to fetch credential schema: {}", e));


### PR DESCRIPTION
## Why

This consolidates the fixable high-severity Rust dependency alerts into one security PR.

## Security fixes

- `pgp` `0.10.2` → `0.14.2`
  - `GHSA-9rmp-2568-59rv` (patched in `0.14.1`)
  - `GHSA-4grw-m28r-q285` (patched in `0.14.2`)
- `rustls-webpki` → `0.103.15`
  - `GHSA-82j2-j2ch-gfr8` (patched in `0.103.13`)
- `rsa` `0.6.1` → `0.9.10`
  - `GHSA-9c48-w39g-hm26` (patched in `0.9.10`)

## What changed

- Migrated the rPGP armor and key APIs in `did-webkey`.
- Upgraded workspace HTTP clients to `reqwest 0.12` so the patched Rustls/WebPKI stack can resolve.
- Migrated RSA key construction and RS256/PS256 signing and verification to the `rsa 0.9` APIs.
- Fixed stable Rust build, clippy, wasm, and feature-matrix compatibility issues exposed by the dependency upgrades.
- Preserved verification compatibility for legacy RDF Data Integrity and EIP-712 proofs without changing modern proof generation.
- Added required VC v1 validation for `issuanceDate` and `credentialStatus.id`.

## Verification

- `cargo fmt -- --check`
- `RUSTFLAGS="-Dwarnings" cargo build --workspace`
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --target wasm32-unknown-unknown`
- `RUSTFLAGS="-Dwarnings" cargo test --examples`
- `RUSTFLAGS="-Dwarnings" cargo test --workspace -- --test-threads=4`
- `cargo hack test --each-feature --workspace --exclude ssi --exclude ssi-did-test --exclude ssi-vc-test -- --test-threads=4`
- `vc-test-suite`: 91 passing, 1 pending

Supersedes #9 and #10.